### PR TITLE
Add getter for ctrlfile to ControlFilePersistenceOutputInfo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ idea.project.languageLevel = '1.8'
 
 subprojects {
 
-    version='0.8.1-SNAPSHOT'
+    version='0.8.1'
 
 
     repositories {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFilePersistenceOutputInfo.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFilePersistenceOutputInfo.java
@@ -21,10 +21,15 @@ import java.nio.file.Path;
 import com.google.common.base.MoreObjects;
 
 public class ControlFilePersistenceOutputInfo {
+
     private final Path ctrlFile;
 
     public ControlFilePersistenceOutputInfo( final Path ctrlFile ) {
         this.ctrlFile = ctrlFile;
+    }
+
+    public Path getCtrlFile() {
+        return ctrlFile;
     }
 
     @Override


### PR DESCRIPTION
In order to attach a processor to a controlledFileWriter, the ControlFilePersistenceOutputInfo must provide the path to the file that has been written.
Otherwise, one has to fetch files in the respective directory in a separate batch job.