### PR TITLE
Fixed ClosedChannelException when reconnecting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ hs_err_pid*
 # IDEA
 *.iml
 .idea/
+
+hostkey.ser

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ subprojects {
 
     dependencies {
         testCompile 'org.testng:testng:6.9.4'
+        testCompile 'org.apache.sshd:sshd-sftp:0.11.0'
     }
 
     checkstyle {

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpClient.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpClient.java
@@ -119,7 +119,7 @@ public class SftpClient implements RemoteClient {
         return sftpChannel;
     }
 
-    protected Session getSession() throws JSchException {
+    protected synchronized Session getSession() throws JSchException {
         if( this.session == null ){
             this.session = createSession();
         }

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpClient.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpClient.java
@@ -18,6 +18,7 @@ package com.freiheit.fuava.sftp;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
@@ -65,6 +66,8 @@ public class SftpClient implements RemoteClient {
     private final InputStream knownHostsInputStream;
     private final StrictHostkeyChecking strictHostkeyChecking;
 
+    private Session session = null;
+
     private ChannelSftp sftpChannel;
 
 
@@ -111,9 +114,16 @@ public class SftpClient implements RemoteClient {
      */
     private ChannelSftp channel() throws JSchException {
         if ( sftpChannel == null || !sftpChannel.isConnected() ) {
-            sftpChannel = login( createSession() );
+            sftpChannel = login( getSession() );
         }
         return sftpChannel;
+    }
+
+    protected Session getSession() throws JSchException {
+        if( this.session == null ){
+            this.session = createSession();
+        }
+        return this.session;
     }
 
     protected Session createSession() throws JSchException {


### PR DESCRIPTION
This exception was seen very rarely in our production logs. It only
happens after a reconnect. The problem is that the JSch is recreated
when the connection is retried which causes the Stream to be read twice.