### PR TITLE
Upgrade gradle to 4.10.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 11 12:15:03 CEST 2015
+#Tue Apr 02 14:06:17 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip


### PR DESCRIPTION
Gradle 2.4 is no longer supported. We need to upgrade to at least 2.6 to be able to run with gradle 5.0