### PR TITLE
Do not depend on Guava.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ idea.project.languageLevel = '1.8'
 
 subprojects {
 
-    version='0.9.5-SNAPSHOT'
+    version='1.0.0-SNAPSHOT'
 
 
     repositories {
@@ -27,7 +27,7 @@ subprojects {
     sourceCompatibility = JavaVersion.VERSION_1_8
 
     dependencies {
-        testCompile 'org.testng:testng:6.9.4'
+        testCompile 'org.testng:testng:7.3.0'
         testCompile 'org.apache.sshd:sshd-sftp:2.3.0'
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,6 @@ jar {
 
 dependencies {
     compile 'com.google.code.findbugs:jsr305:3.0.0'
-    compile 'com.google.guava:guava:18.0'
     compile 'org.apache.httpcomponents:httpclient:4.5'
     compile 'org.apache.httpcomponents:httpcore:4.4.1'
     compile 'org.slf4j:slf4j-api:1.7.12'

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/BatchJobMain.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/BatchJobMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/DownloadDir.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/DownloadDir.java
@@ -1,11 +1,10 @@
 package com.freiheit.fuava.simplebatch.fetch;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-
-import com.google.common.base.Preconditions;
 
 public final class DownloadDir {
     private final Path path;
@@ -13,9 +12,9 @@ public final class DownloadDir {
     private final String suffix;
     
     public DownloadDir( final Path path, @Nullable final String prefix, final String suffix ) {
-        this.path = Preconditions.checkNotNull( path );
+        this.path = Objects.requireNonNull( path );
         this.prefix = prefix;
-        this.suffix = Preconditions.checkNotNull( suffix );
+        this.suffix = Objects.requireNonNull( suffix );
     }
     
     public Path getPath() {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/FailsafeIterator.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/FailsafeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,14 +34,14 @@ public final class FailsafeIterator<OriginalInput> implements Iterator<Result<Fe
     @Override
     public boolean hasNext() {
         if ( forceHasNext != null ) {
-            return forceHasNext.booleanValue();
+            return forceHasNext;
         }
         try {
             return iterator.hasNext();
         } catch ( final Throwable t ) {
             forceHasNext = Boolean.TRUE;
             forceNextElement = Result.failed( nextFetchedItem( null ), "Failed to call hasNext on delegate iterator", t );
-            return forceHasNext.booleanValue();
+            return forceHasNext;
         }
     }
 

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/FetchedItem.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/FetchedItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/Fetcher.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/Fetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/Fetchers.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/Fetchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,20 +16,18 @@
  */
 package com.freiheit.fuava.simplebatch.fetch;
 
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.util.Map;
-
-import org.apache.http.client.HttpClient;
-
 import com.freiheit.fuava.simplebatch.http.HttpFetcher;
 import com.freiheit.fuava.simplebatch.http.HttpFetcherImpl;
 import com.freiheit.fuava.simplebatch.http.HttpPagingFetcher;
 import com.freiheit.fuava.simplebatch.http.PagingRequestSettings;
-import com.google.common.base.Function;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-import com.google.common.collect.Ordering;
+import org.apache.http.client.HttpClient;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class Fetchers {
 
@@ -37,8 +35,8 @@ public class Fetchers {
      * Uses the given iterable to provide the data that will be passed on to the
      * processing stage, treating each item as successful.
      */
-    public static final <OriginalInput> Fetcher<OriginalInput> iterable( final Iterable<OriginalInput> iterable ) {
-        return new SuppliedIterableFetcher<OriginalInput>( Suppliers.ofInstance( iterable ) );
+    public static <OriginalInput> Fetcher<OriginalInput> iterable( final Iterable<OriginalInput> iterable ) {
+        return new SuppliedIterableFetcher<>( () -> iterable );
     }
 
     /**
@@ -46,7 +44,7 @@ public class Fetchers {
      * will be passed on to the processing stage, treating each item as
      * successful.
      */
-    public static final <OriginalInput> Fetcher<OriginalInput> supplied( final Supplier<Iterable<OriginalInput>> supplier ) {
+    public static <OriginalInput> Fetcher<OriginalInput> supplied( final Supplier<Iterable<OriginalInput>> supplier ) {
         return new SuppliedIterableFetcher<OriginalInput>( supplier );
     }
 
@@ -125,7 +123,7 @@ public class Fetchers {
             final int initialFrom,
             final int pageSize
             ) {
-        return new HttpPagingFetcher<OriginalInput>( fetcher, settings, converter, initialFrom, pageSize );
+        return new HttpPagingFetcher<>( fetcher, settings, converter, initialFrom, pageSize );
 
     }
 
@@ -135,15 +133,15 @@ public class Fetchers {
      * specified fileEnding and converts them with the given function.
      */
     public static <OriginalInput> Fetcher<OriginalInput> folderFetcher( final Function<Path, OriginalInput> fileFunction, final DownloadDir dir, final DownloadDir... moreDirs ) {
-        return new DirectoryFileFetcher<OriginalInput>( fileFunction, DirectoryFileFetcher.ORDERING_FILE_BY_PATH, dir, moreDirs );
+        return new DirectoryFileFetcher<>( fileFunction, DirectoryFileFetcher.ORDERING_FILE_BY_PATH, dir, moreDirs );
     }
 
     /**
      * Iterates over all files in the given directories that end with the
      * specified fileEnding and converts them with the given function.
      */
-    public static <OriginalInput> Fetcher<OriginalInput> folderFetcher( final Function<Path, OriginalInput> fileFunction, final Ordering<Path> fileOrdering, final DownloadDir dir, final DownloadDir... moreDirs ) {
-        return new DirectoryFileFetcher<OriginalInput>( fileFunction, fileOrdering, dir, moreDirs );
+    public static <OriginalInput> Fetcher<OriginalInput> folderFetcher( final Function<Path, OriginalInput> fileFunction, final Comparator<Path> fileOrdering, final DownloadDir dir, final DownloadDir... moreDirs ) {
+        return new DirectoryFileFetcher<>( fileFunction, fileOrdering, dir, moreDirs );
     }
 
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/IterableFetcherWrapper.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/IterableFetcherWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,11 @@
  */
 package com.freiheit.fuava.simplebatch.fetch;
 
-import java.util.Iterator;
-
 import com.freiheit.fuava.simplebatch.result.Result;
 import com.freiheit.fuava.simplebatch.util.EagernessUtil;
-import com.google.common.collect.Iterators;
+
+import java.util.Collections;
+import java.util.Iterator;
 
 public final class IterableFetcherWrapper<OriginalInput> implements Iterable<Result<FetchedItem<OriginalInput>, OriginalInput>> {
     private final Iterable<OriginalInput> iterable;
@@ -36,9 +36,9 @@ public final class IterableFetcherWrapper<OriginalInput> implements Iterable<Res
     @Override
     public Iterator<Result<FetchedItem<OriginalInput>, OriginalInput>> iterator() {
         try {
-            return new FailsafeIterator<OriginalInput>( iterable.iterator() );
+            return new FailsafeIterator<>( iterable.iterator() );
         } catch ( final Throwable t ) {
-            return Iterators.singletonIterator( Result.failed( null, t ) );
+            return Collections.<Result<FetchedItem<OriginalInput>, OriginalInput>>singletonList( Result.failed( null, t ) ).iterator();
         }
     }
 

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/LazyPageFetchingIterable.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/LazyPageFetchingIterable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/PageFetcher.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/PageFetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/PageFetchingSettings.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/PageFetchingSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,9 @@ package com.freiheit.fuava.simplebatch.fetch;
 
 import com.freiheit.fuava.simplebatch.fetch.PageFetcher.PagingInput;
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.collect.Iterables;
+
+import java.util.Collection;
+import java.util.stream.StreamSupport;
 
 public interface PageFetchingSettings<T> {
     default boolean hasNext( final int from, final int amount, final Result<PagingInput, T> lastValue ) {
@@ -26,11 +28,14 @@ public interface PageFetchingSettings<T> {
             return false;
         }
         final Object output = lastValue.getOutput();
-        if ( output instanceof Iterable ) {
-            return Iterables.size( (Iterable) output ) >= amount;
+
+        if ( output instanceof Collection ) {
+            return ( (Collection<?>) output ).size() >= amount;
+        } else if ( output instanceof Iterable ) {
+            final long size = StreamSupport.stream( ( (Iterable<?>) output ).spliterator(), false).count();
+            return size >= amount;
         }
         throw new UnsupportedOperationException( "cannot calculate paging for " + output
                 + " - please provide your own implementation" );
-
     }
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/SuppliedIterableFetcher.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fetch/SuppliedIterableFetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,9 @@
 package com.freiheit.fuava.simplebatch.fetch;
 
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableList;
+
+import java.util.Collections;
+import java.util.function.Supplier;
 
 public final class SuppliedIterableFetcher<OriginalInput> implements Fetcher<OriginalInput> {
     private final Supplier<Iterable<OriginalInput>> supplier;
@@ -33,8 +34,7 @@ public final class SuppliedIterableFetcher<OriginalInput> implements Fetcher<Ori
             final Iterable<OriginalInput> originalIterable = this.supplier.get();
             return IterableFetcherWrapper.wrap( originalIterable );
         } catch ( final Throwable t ) {
-            return ImmutableList.of( Result.failed( null, t ) );
+            return Collections.singletonList( Result.failed( null, t ) );
         }
     }
-
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/downloader/CtlDownloaderJob.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/downloader/CtlDownloaderJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package com.freiheit.fuava.simplebatch.fsjobs.downloader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 
 import com.freiheit.fuava.simplebatch.BatchJob;
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
@@ -34,7 +35,6 @@ import com.freiheit.fuava.simplebatch.processor.TimeLoggingProcessor;
 import com.freiheit.fuava.simplebatch.result.ProcessingResultListener;
 import com.freiheit.fuava.simplebatch.util.FileUtils;
 import com.freiheit.fuava.simplebatch.util.Sysprops;
-import com.google.common.base.Preconditions;
 
 /**
  * An importer that imports files from the file system, adhering to the control
@@ -163,8 +163,8 @@ public class CtlDownloaderJob<OriginalInput, Output> extends BatchJob<OriginalIn
 
         public CtlDownloaderJob<OriginalInput, ControlFilePersistenceOutputInfo> build() {
             final Configuration configuration = getConfiguration();
-            Preconditions.checkNotNull( configuration, "Configuration missing" );
-            Preconditions.checkNotNull( persistenceAdapter, "File Writer Adapter missing" );
+            Objects.requireNonNull( configuration, "Configuration missing" );
+            Objects.requireNonNull( persistenceAdapter, "File Writer Adapter missing" );
 
             return build( Processors.controlledFileWriter(
                     configuration.getDownloadDirPath(),
@@ -327,8 +327,8 @@ public class CtlDownloaderJob<OriginalInput, Output> extends BatchJob<OriginalIn
 
         public CtlDownloaderJob<Input, BatchProcessorResult<ControlFilePersistenceOutputInfo>> build() {
             final Configuration configuration = getConfiguration();
-            Preconditions.checkNotNull( configuration, "Configuration missing" );
-            Preconditions.checkNotNull( persistenceAdapter, "File Writer Adapter missing" );
+            Objects.requireNonNull( configuration, "Configuration missing" );
+            Objects.requireNonNull( persistenceAdapter, "File Writer Adapter missing" );
 
             return build( Processors.controlledBatchFileWriter(
                     configuration.getDownloadDirPath(),
@@ -441,10 +441,10 @@ public class CtlDownloaderJob<OriginalInput, Output> extends BatchJob<OriginalIn
          * @return the job
          */
         public CtlDownloaderJob<OriginalInput, Output> build( final Processor<FetchedItem<OriginalInput>, Input, Output> fileWriter ) {
-            Preconditions.checkNotNull( fileWriter, "You need to call setFileWriterAdapter first" );
-            Preconditions.checkNotNull( downloader, "You need to set a downloader" );
+            Objects.requireNonNull( fileWriter, "You need to call setFileWriterAdapter first" );
+            Objects.requireNonNull( downloader, "You need to set a downloader" );
             final Fetcher<OriginalInput> fetcher = builder.getFetcher();
-            Preconditions.checkNotNull( fetcher, "Fetcher missing." );
+            Objects.requireNonNull( fetcher, "Fetcher missing." );
 
             builder.addListener( new BatchStatisticsLoggingListener<OriginalInput, Output>( LOG_NAME_BATCH ) );
             builder.addListener( new ItemProgressLoggingListener<OriginalInput, Output>( LOG_NAME_ITEM ) );

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/downloader/CtlDownloaderJobMain.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/downloader/CtlDownloaderJobMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/ControlFile.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/ControlFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +16,14 @@
  */
 package com.freiheit.fuava.simplebatch.fsjobs.importer;
 
-import java.nio.file.Path;
-
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
+import java.nio.file.Path;
 
 /**
  * @author tim.lessner@freiheit.com
  */
 public class ControlFile {
-
     private final Path relControlledFile;
     private final Path relLogFile;
     private final Path relControlFile;
@@ -50,11 +45,19 @@ public class ControlFile {
             @Nullable final String status 
     ) {
         this.originalControlledFileName = originalControlledFileName;
-        Preconditions.checkArgument( controlledFileRelPath == null || !controlledFileRelPath.isAbsolute(), "Controlled File Path must not be absolute" );
-        Preconditions.checkArgument( !logFileRelPath.isAbsolute(), "Log File Path must not be absolute" );
-        Preconditions.checkArgument( !controlFileRelPath.isAbsolute(), "Control File Path must not be absolute" );
-        Preconditions.checkArgument( baseDir.isAbsolute(), "Base Dir Path must be absolute" );
-        
+        if ( controlledFileRelPath != null && controlledFileRelPath.isAbsolute() ) {
+            throw new IllegalArgumentException( "Controlled File Path must not be absolute, but was: " + controlledFileRelPath );
+        }
+        if ( logFileRelPath.isAbsolute() ) {
+            throw new IllegalArgumentException( "Log File Path must not be absolute, but was: " + logFileRelPath );
+        }
+        if ( controlFileRelPath.isAbsolute() ) {
+            throw new IllegalArgumentException( "Control File Path must not be absolute, but was: " + controlFileRelPath );
+        }
+        if ( !baseDir.isAbsolute() ) {
+            throw new IllegalArgumentException( "Base Dir Path must be absolute, but was: " + baseDir );
+        }
+
         this.status = status;
         this.downloadFailed = "DOWNLOAD_FAILED".equals( status );;
         this.baseDir = baseDir;
@@ -122,7 +125,10 @@ public class ControlFile {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper( this ).add( "file", this.relControlledFile ).add( "ctl", this.relControlFile ).add( "log", this.relLogFile ).toString();
+        return "ControlFile{" +
+                "file=" + relControlledFile +
+                ", ctl=" + relControlFile +
+                ", log=" + relLogFile +
+                '}';
     }
-
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/CtlImporterJobMain.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/CtlImporterJobMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/FailedToMoveFileException.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/FailedToMoveFileException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/FileToInputStreamFunction.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/FileToInputStreamFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,11 +19,10 @@ package com.freiheit.fuava.simplebatch.fsjobs.importer;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Function;
 
 /**
  * .

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/ImportContentJsonLoggingListenerFactory.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/fsjobs/importer/ImportContentJsonLoggingListenerFactory.java
@@ -1,14 +1,15 @@
 package com.freiheit.fuava.simplebatch.fsjobs.importer;
 
-import java.nio.file.Path;
-
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
 import com.freiheit.fuava.simplebatch.logging.JsonLogger;
 import com.freiheit.fuava.simplebatch.result.ProcessingResultListener;
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
 
 public class ImportContentJsonLoggingListenerFactory<Data>
         implements Function<FetchedItem<ControlFile>, ProcessingResultListener<Data, Data>> {
@@ -31,10 +32,12 @@ public class ImportContentJsonLoggingListenerFactory<Data>
                     ? null
                     : fetchedItem.getIdentifier();
 
+                final List<String> messages = new ArrayList<>();
+                result.getWarningMessages().forEach( messages::add );
+                result.getFailureMessages().forEach( messages::add );
+
                 logger.logImportItem( result.isSuccess(), result.getInput().getNum(),
-                        ImmutableList.copyOf(
-                                Iterables.concat( result.getWarningMessages(), result.getFailureMessages() ) ),
-                        identifier );
+                        Collections.unmodifiableList( messages ), identifier );
             }
         };
     }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/http/HttpDownloaderSettings.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/http/HttpDownloaderSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/http/HttpFetcher.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/http/HttpFetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,12 +18,11 @@ package com.freiheit.fuava.simplebatch.http;
 
 import java.io.InputStream;
 import java.util.Map;
+import java.util.function.Function;
 
 import com.freiheit.fuava.simplebatch.exceptions.FetchFailedException;
-import com.google.common.base.Function;
 
 public interface HttpFetcher {
-
     public <T> T fetch(
             final Function<? super InputStream, T> reader,
             final String uri,

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/http/HttpFetcherImpl.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/http/HttpFetcherImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,24 +16,20 @@
  */
 package com.freiheit.fuava.simplebatch.http;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.freiheit.fuava.simplebatch.exceptions.AuthorizationException;
 import com.freiheit.fuava.simplebatch.exceptions.FetchFailedException;
 import com.freiheit.fuava.simplebatch.util.IOStreamUtils;
-import com.google.common.base.Function;
-import com.google.common.base.Supplier;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class HttpFetcherImpl implements HttpFetcher {
-    static final Logger LOG = LoggerFactory.getLogger( HttpFetcherImpl.class );
     private final Supplier<HttpClient> _client;
 
     public HttpFetcherImpl( final HttpClient client ) {
@@ -74,7 +70,6 @@ public class HttpFetcherImpl implements HttpFetcher {
 
             try ( InputStream stream = response.getEntity().getContent() ) {
                 final T result = reader.apply( stream );
-                LOG.debug( String.format( "transformed request result: %s", result ) );
                 return result;
             }
         } catch ( final IOException e ) {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/http/HttpPageFetcher.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/http/HttpPageFetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,10 @@
 package com.freiheit.fuava.simplebatch.http;
 
 import java.io.InputStream;
+import java.util.function.Function;
 
 import com.freiheit.fuava.simplebatch.fetch.PageFetcher;
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Function;
 
 public class HttpPageFetcher<T> implements PageFetcher<T> {
     private final PagingRequestSettings<T> settings;

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/http/PagingRequestSettings.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/http/PagingRequestSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/http/RequestSettings.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/http/RequestSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,11 @@
  */
 package com.freiheit.fuava.simplebatch.http;
 
+import java.util.Collections;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
 
 public interface RequestSettings {
     default Map<String, String> getRequestHeaders() {
-        return ImmutableMap.<String, String> of();
+        return Collections.emptyMap();
     }
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/logging/BatchStatisticsLoggingListener.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/logging/BatchStatisticsLoggingListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +16,13 @@
  */
 package com.freiheit.fuava.simplebatch.logging;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
 import com.freiheit.fuava.simplebatch.result.ProcessingResultListener;
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.collect.FluentIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.stream.StreamSupport;
 
 /**
  * Logs the {@link ResultBatchStat} of processing a single batch.
@@ -44,16 +44,15 @@ public class BatchStatisticsLoggingListener<Input, Output> implements Processing
 
     @Override
     public void onFetchResults( final Iterable<Result<FetchedItem<Input>, Input>> result ) {
-        final int failed = FluentIterable.from( result ).filter( Result::isFailed ).size();
-        final int success = FluentIterable.from( result ).filter( Result::isSuccess ).size();
+        final long failed = StreamSupport.stream( result.spliterator(), false ).filter( Result::isFailed ).count();
+        final long success = StreamSupport.stream( result.spliterator(), false ).filter( Result::isSuccess ).count();
         log.info( ResultBatchStat.of( Event.FETCH, failed, success, _description ) );
     }
 
     @Override
     public void onProcessingResults( final Iterable<? extends Result<FetchedItem<Input>, Output>> iterable ) {
-        final int failed = FluentIterable.from( iterable ).filter( Result::isFailed ).size();
-        final int success = FluentIterable.from( iterable ).filter( Result::isSuccess ).size();
+        final long failed = StreamSupport.stream( iterable.spliterator(), false ).filter( Result::isFailed ).count();
+        final long success = StreamSupport.stream( iterable.spliterator(), false ).filter( Result::isSuccess ).count();
         log.info( ResultBatchStat.of( Event.PROCESSING, failed, success, _description ) );
-
     }
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/logging/Event.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/logging/Event.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/logging/ImportFileJsonLoggingListener.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/logging/ImportFileJsonLoggingListener.java
@@ -10,7 +10,6 @@ import com.freiheit.fuava.simplebatch.result.Result;
 import com.freiheit.fuava.simplebatch.result.ResultStatistics;
 
 public class ImportFileJsonLoggingListener implements ProcessingResultListener<ControlFile, ResultStatistics> {
-
     private final Path downloadDir;
     private final Path archivedDir;
     private final Path failedDir;

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/logging/ItemProgressLoggingListener.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/logging/ItemProgressLoggingListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/logging/JsonLogger.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/logging/JsonLogger.java
@@ -5,19 +5,20 @@ package com.freiheit.fuava.simplebatch.logging;
  * Created on Nov 17, 2015 by
  * Benjamin Teuber (benjamin.teuber@freiheit.com)
  */
+
+import com.freiheit.fuava.simplebatch.util.StringUtils;
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableList;
-import com.google.gson.Gson;
 
 /**
  * This class sets up per-file json logging for the importer, downloader etc
@@ -33,7 +34,7 @@ public class JsonLogger {
 
     public static Path nextFailedDownloadsName() {
         final String prefix = "" + System.currentTimeMillis();
-        final String count = com.google.common.base.Strings.padStart(
+        final String count = StringUtils.padStart(
                 Long.toString( counter.incrementAndGet() ),
                 3,
                 '0' );
@@ -63,7 +64,7 @@ public class JsonLogger {
     }
 
     public void logImportStart( final String identifier ) {
-        log( new JsonLogEntry( "import", "start", null, null, null, ImmutableList.of(), identifier ) );
+        log( new JsonLogEntry( "import", "start", null, null, null, Collections.emptyList(), identifier ) );
     }
 
     public void logImportEnd( final boolean isSuccess, final List<String> messages, final String identifier ) {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/logging/ResultBatchStat.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/logging/ResultBatchStat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,17 +23,16 @@ package com.freiheit.fuava.simplebatch.logging;
  * @author tim.lessner@freiheit.com
  */
 public class ResultBatchStat {
-
     private final Event event;
-    private final int failed;
-    private final int success;
+    private final long failed;
+    private final long success;
     private final String description;
 
-    public static String of( final Event event, final int failed, final int success, final String description ) {
+    public static String of( final Event event, final long failed, final long success, final String description ) {
         return new ResultBatchStat( event, failed, success, description ).toString();
     }
 
-    public ResultBatchStat( final Event event, final int failed, final int success, final String description ) {
+    public ResultBatchStat( final Event event, final long failed, final long success, final String description ) {
         this.event = event;
         this.failed = failed;
         this.success = success;

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/logging/ResultItemStat.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/logging/ResultItemStat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ package com.freiheit.fuava.simplebatch.logging;
  * @author tim.lessner@freiheit.com
  */
 public class ResultItemStat {
-
     private final Event event;
     private final Iterable<String> failureMessage;
     private final Iterable<Throwable> throwables;

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/AbstractControlledFileMovingProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/AbstractControlledFileMovingProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/AbstractSingleItemProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/AbstractSingleItemProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,17 +17,17 @@
 package com.freiheit.fuava.simplebatch.processor;
 
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.collect.ImmutableList;
+
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public abstract class AbstractSingleItemProcessor<OriginalItem, Input, Output> implements Processor<OriginalItem, Input, Output> {
-
     @Override
     public final Iterable<Result<OriginalItem, Output>> process( final Iterable<Result<OriginalItem, Input>> iterable ) {
-        final ImmutableList.Builder<Result<OriginalItem, Output>> b = ImmutableList.builder();
-        for ( final Result<OriginalItem, Input> input : iterable ) {
-            b.add( processItem( input ) );
-        }
-        return b.build();
+        return Collections.unmodifiableList( StreamSupport.stream( iterable.spliterator(), false )
+                .map( this::processItem )
+                .collect( Collectors.toList() ) );
     }
 
     public abstract Result<OriginalItem, Output> processItem( Result<OriginalItem, Input> input );

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/AbstractStringFileWriterAdapter.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/AbstractStringFileWriterAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/BatchProcessorResult.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/BatchProcessorResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ChainedProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ChainedProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ComposedProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ComposedProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ContentProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ContentProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,13 +17,13 @@
 package com.freiheit.fuava.simplebatch.processor;
 
 import java.util.List;
+import java.util.function.Function;
 
 import com.freiheit.fuava.simplebatch.BatchJob;
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
 import com.freiheit.fuava.simplebatch.result.ProcessingResultListener;
 import com.freiheit.fuava.simplebatch.result.Result;
 import com.freiheit.fuava.simplebatch.result.ResultStatistics;
-import com.google.common.base.Function;
 
 final class ContentProcessor<Input, Data>
         extends AbstractSingleItemProcessor<Input, Iterable<Result<FetchedItem<Data>, Data>>, ResultStatistics> {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFileMover.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFileMover.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFilePersistence.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFilePersistence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,15 +16,14 @@
  */
 package com.freiheit.fuava.simplebatch.processor;
 
+import com.freiheit.fuava.simplebatch.result.Result;
+
 import java.io.File;
 import java.nio.file.Path;
-
-import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 /**
  * @param <Input>
- * @param <Output>
  */
 class ControlFilePersistence<Input> extends
         AbstractSingleItemProcessor<Input, FilePersistenceOutputInfo, ControlFilePersistenceOutputInfo> {
@@ -42,7 +41,7 @@ class ControlFilePersistence<Input> extends
     
     public ControlFilePersistence( final Configuration config ) {
         this.config = config;
-        this.downloadDirPath = Preconditions.checkNotNull( config.getDownloadDirPath() );
+        this.downloadDirPath = Objects.requireNonNull( config.getDownloadDirPath() );
     }
 
     @Override

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFilePersistenceConfigImpl.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFilePersistenceConfigImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFilePersistenceOutputInfo.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFilePersistenceOutputInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,6 @@ package com.freiheit.fuava.simplebatch.processor;
 
 import java.nio.file.Path;
 
-import com.google.common.base.MoreObjects;
-
 public class ControlFilePersistenceOutputInfo {
 
     private final Path ctrlFile;
@@ -34,6 +32,8 @@ public class ControlFilePersistenceOutputInfo {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper( this ).add( "Control File", ctrlFile ).toString();
+        return "ControlFilePersistenceOutputInfo{" +
+                "Control File=" + ctrlFile +
+                '}';
     }
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFileWriter.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/ControlFileWriter.java
@@ -1,18 +1,15 @@
 package com.freiheit.fuava.simplebatch.processor;
 
+import com.freiheit.fuava.simplebatch.fsjobs.importer.ControlFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.freiheit.fuava.simplebatch.fsjobs.importer.ControlFile;
-import com.google.common.base.Preconditions;
-
 public class ControlFileWriter {
-
     public static final Logger LOG = LoggerFactory.getLogger( ControlFileWriter.class );
 
     public static void write( final ControlFile controlFile ) {
@@ -20,21 +17,25 @@ public class ControlFileWriter {
     }
     
     public static void write( final Path controlFile, final String status, final Path commonBaseDir, final Path controlledFileName, final Path logFileName ) {
-        Preconditions.checkArgument( controlFile.isAbsolute(), "Expected an absolute Path for control file" );
-        Preconditions.checkArgument( controlFile.startsWith( commonBaseDir ), "Control File is not in the common Base Dir" );
-        Preconditions.checkArgument( controlledFileName.isAbsolute(), "Expected an absolute Path for controlled file" );
-        Preconditions.checkArgument( controlledFileName.startsWith( commonBaseDir ), "Controlled File is not in the common Base Dir" );
-        Preconditions.checkArgument( logFileName.isAbsolute(), "Expected an absolute Path for control file" );
-        Preconditions.checkArgument( logFileName.startsWith( commonBaseDir ), "Log File is not in the common Base Dir" );
+        checkAbsolute( controlFile, "control" );
+        checkCommonBase( controlFile, commonBaseDir, "control" );
+        checkAbsolute( controlledFileName, "controlled" );
+        checkCommonBase( controlledFileName, commonBaseDir, "Controlled" );
+        checkAbsolute( logFileName, "log" );
+        checkCommonBase( logFileName, commonBaseDir, "Log" );
 
         final Path controlledFileRelPath = commonBaseDir.relativize( controlledFileName );
         write( controlFile, status, controlledFileRelPath, commonBaseDir.relativize( logFileName), controlledFileRelPath.toString() );
     }
     
     private static void write( final Path controlFile, final String status, final Path controlledFileName, final Path logFileName, final String originalFileName ) {
-        Preconditions.checkArgument( controlFile.isAbsolute(), "Expected an absolute Path for control file" );
-        Preconditions.checkArgument( controlledFileName == null || !controlledFileName.isAbsolute(), "Expected a relative Path for controlled file" );
-        Preconditions.checkArgument( !logFileName.isAbsolute(), "Expected a relative Path for control file" );
+        checkAbsolute( controlFile, "control" );
+        if ( controlledFileName != null && controlledFileName.isAbsolute() ) {
+            throw new IllegalArgumentException( "Expected a relative Path for controlled file, but was " + controlledFileName );
+        }
+        if ( logFileName.isAbsolute() ) {
+            throw new IllegalArgumentException( "Expected a relative Path for log file, but was " + logFileName );
+        }
         final String failCtlContent = "#!VERSION=1\n" +
                 "status=" + status + "\n" +
                 "file=" + ( controlledFileName == null ? "" : controlledFileName.toString() ) + "\n" +
@@ -44,6 +45,18 @@ public class ControlFileWriter {
             Files.write( controlFile, failCtlContent.getBytes("UTF-8"), StandardOpenOption.CREATE );
         } catch ( final IOException e ) {
             LOG.error( e.getMessage() );
+        }
+    }
+
+    private static void checkAbsolute( final Path path, final String name ) {
+        if ( !path.isAbsolute() ) {
+            throw new IllegalArgumentException( "Expected an absolute Path for " + name + " file, but was " + path );
+        }
+    }
+
+    private static void checkCommonBase( final Path path, final Path commonBase, final String name ) {
+        if ( !path.startsWith( commonBase ) ) {
+            throw new IllegalArgumentException( name + " file is not in the common base dir [" + commonBase + "], instead it is " + path );
         }
     }
 

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FileMovingProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FileMovingProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FileOutputStreamAdapter.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FileOutputStreamAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FilePersistence.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FilePersistence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,17 +16,16 @@
  */
 package com.freiheit.fuava.simplebatch.processor;
 
+import com.freiheit.fuava.simplebatch.result.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 /**
  * @param <Input>
@@ -40,7 +39,7 @@ class FilePersistence<Input, Output> extends AbstractSingleItemProcessor<Input, 
     private final Path basePath;
 
     public FilePersistence( final Path dir, final FileOutputStreamAdapter<Input, Output> adapter ) {
-        this.adapter = Preconditions.checkNotNull( adapter );
+        this.adapter = Objects.requireNonNull( adapter );
         final File basedir = dir.toFile();
         if ( !basedir.exists() ) {
             if ( basedir.mkdirs() ) {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FilePersistenceOutputInfo.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FilePersistenceOutputInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,15 +17,13 @@
 package com.freiheit.fuava.simplebatch.processor;
 
 import java.nio.file.Path;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 public class FilePersistenceOutputInfo {
     private final Path dataFile;
 
     public FilePersistenceOutputInfo( final Path dataFile ) {
-        this.dataFile = Preconditions.checkNotNull( dataFile );
+        this.dataFile = Objects.requireNonNull( dataFile );
     }
 
     public Path getDataFile() {
@@ -34,6 +32,8 @@ public class FilePersistenceOutputInfo {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper( this ).add( "Data File", dataFile ).toString();
+        return "FilePersistenceOutputInfo{" +
+                "Data File=" + dataFile +
+                '}';
     }
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FileWriterAdapter.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/FileWriterAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,12 @@
  */
 package com.freiheit.fuava.simplebatch.processor;
 
+import com.freiheit.fuava.simplebatch.result.Result;
+
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-
-import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Charsets;
+import java.nio.charset.StandardCharsets;
 
 public interface FileWriterAdapter<Input, Output> extends FileOutputStreamAdapter<Input, Output> {
     @Override
@@ -29,7 +29,7 @@ public interface FileWriterAdapter<Input, Output> extends FileOutputStreamAdapte
 
     @Override
     default public void writeToStream( final java.io.OutputStream outputStream, final Output data ) throws IOException {
-        try ( OutputStreamWriter fos = new OutputStreamWriter( outputStream, Charsets.UTF_8 ) ) {
+        try ( OutputStreamWriter fos = new OutputStreamWriter( outputStream, StandardCharsets.UTF_8 ) ) {
             write( fos, data );
             fos.flush();
         }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/HttpDownloader.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/HttpDownloader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,8 @@
 package com.freiheit.fuava.simplebatch.processor;
 
 import java.io.InputStream;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.http.client.HttpClient;
 
@@ -24,11 +26,8 @@ import com.freiheit.fuava.simplebatch.http.HttpDownloaderSettings;
 import com.freiheit.fuava.simplebatch.http.HttpFetcher;
 import com.freiheit.fuava.simplebatch.http.HttpFetcherImpl;
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Function;
-import com.google.common.base.Supplier;
 
 class HttpDownloader<Input, Id, T> extends AbstractSingleItemProcessor<Input, Id, T> {
-
     private final HttpFetcher fetcher;
     private final HttpDownloaderSettings<Id> settings;
     private final Function<InputStream, T> converter;

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/Processor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/Processor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/Processors.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/Processors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,8 @@ import java.io.Writer;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.http.client.HttpClient;
 import org.slf4j.Logger;
@@ -35,8 +37,6 @@ import com.freiheit.fuava.simplebatch.result.ProcessingResultListener;
 import com.freiheit.fuava.simplebatch.result.Result;
 import com.freiheit.fuava.simplebatch.result.ResultStatistics;
 import com.freiheit.fuava.simplebatch.util.IOStreamUtils;
-import com.google.common.base.Function;
-import com.google.common.base.Supplier;
 
 public class Processors {
 

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/RetryingFunctionProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/RetryingFunctionProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,7 @@
 package com.freiheit.fuava.simplebatch.processor;
 
 import java.util.List;
-
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * A processor implementation which delegates processing of lists of

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/RetryingResultFunctionProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/RetryingResultFunctionProcessor.java
@@ -20,8 +20,9 @@
 package com.freiheit.fuava.simplebatch.processor;
 
 import java.util.List;
+import java.util.function.Function;
+
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Function;
 
 /**
  * A processor implementation which delegates processing of lists of

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/SingleItemFunctionProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/SingleItemFunctionProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  */
 package com.freiheit.fuava.simplebatch.processor;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 public class SingleItemFunctionProcessor<OriginalItem, Input, Output> extends
         SingleItemProcessor<OriginalItem, Input, Output> {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/SingleItemProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/SingleItemProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/SingleResultFunctionProcessor.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/SingleResultFunctionProcessor.java
@@ -20,7 +20,8 @@
 package com.freiheit.fuava.simplebatch.processor;
 
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Function;
+
+import java.util.function.Function;
 
 public class SingleResultFunctionProcessor<OriginalItem, Input, Output> extends
     SingleResultProcessor<OriginalItem, Input, Output> {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/processor/StringFileWriterAdapter.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/processor/StringFileWriterAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/result/Counts.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/result/Counts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/result/DelegatingProcessingResultListener.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/result/DelegatingProcessingResultListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/result/ProcessingResultListener.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/result/ProcessingResultListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/result/ResultStatistics.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/result/ResultStatistics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/util/EagernessUtil.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/util/EagernessUtil.java
@@ -1,20 +1,22 @@
 package com.freiheit.fuava.simplebatch.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
-
-import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
 
 public class EagernessUtil {
-    
     /**
-     * It may seem useless at first do enforce eagerness , but the BatchJob
+     * It may seem useless at first do enforce eagerness, but the BatchJob
      * will try to collect and print statistics only if the iterable is a Collection.
      * 
      * If our input was a List we know it is not really lazy, so we can eagerly fetch it.
      */
     public static <R> Iterable<R> preserveEagerness( final Iterable<?> originalIterable, final Iterable<R> resultingIterable ) {
         if ( originalIterable instanceof Collection ) {
-            return ImmutableList.copyOf( resultingIterable );
+            final List<R> result = new ArrayList<>();
+            resultingIterable.forEach( result::add );
+            return Collections.unmodifiableList( result );
         }
         return resultingIterable;
     }
@@ -24,6 +26,8 @@ public class EagernessUtil {
      * will try to collect and print statistics only if the iterable is a Collection.
      */
     public static <R> Iterable<R> preserveEagerness( final Iterable<R> resultingIterable ) {
-        return ImmutableList.copyOf( resultingIterable );
+        final List<R> result = new ArrayList<>();
+        resultingIterable.forEach( result::add );
+        return Collections.unmodifiableList( result );
     }
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/util/FileUtils.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/util/FileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,6 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 public class FileUtils {
-
     public static final String PLACEHOLDER_DATE = "%(DATE)";
 
     public static void deleteDirectoryRecursively( final File dir ) throws IOException {

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/util/IOStreamUtils.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/util/IOStreamUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +16,15 @@
  */
 package com.freiheit.fuava.simplebatch.util;
 
+import com.freiheit.fuava.simplebatch.exceptions.FetchFailedException;
+
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
-import com.freiheit.fuava.simplebatch.exceptions.FetchFailedException;
-import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
 
 /**
  * Utility functions for iostream handling within the fuava simplebatch project.
@@ -31,7 +33,6 @@ import com.google.common.io.CharStreams;
  *
  */
 public final class IOStreamUtils {
-
     private IOStreamUtils() {
         // static util class constructor
     }
@@ -43,10 +44,11 @@ public final class IOStreamUtils {
      */
     public static String consumeAsString( final InputStream istream ) throws FetchFailedException {
         try {
-            try ( InputStream stream = istream ) {
-                return CharStreams.toString( new InputStreamReader( stream, Charsets.UTF_8 ) );
+            try ( final BufferedReader reader = new BufferedReader( new InputStreamReader( istream, StandardCharsets.UTF_8 ) ) ) {
+                return reader.lines()
+                        .collect( Collectors.joining( "\n" ) );
             }
-        } catch ( final IOException e ) {
+        } catch ( final IOException | UncheckedIOException e ) {
             throw new FetchFailedException( e );
         }
     }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/util/IterableUtils.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/util/IterableUtils.java
@@ -1,0 +1,93 @@
+package com.freiheit.fuava.simplebatch.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Helper functions to better deal with Iterables.
+ * @author Matthias Bender (matthias.bender@freiheit.com)
+ */
+public class IterableUtils {
+    /**
+     * Checks whether a given Iterable is actually empty.
+     * @param iterable The Iterable to check.
+     * @return true will be returned if there is no item to be iterated over. Otherwise false.
+     */
+    public static <T> boolean isEmpty( final Iterable<T> iterable ) {
+        if ( iterable instanceof Collection ) {
+            return ( (Collection<T>) iterable ).isEmpty();
+        }
+        return !iterable.iterator().hasNext();
+    }
+
+    /**
+     * Converts a given iterable to a List. If the Iterable already is of type List it will simply
+     * be returned.
+     * @return A new (immutable) list is being returned unless the given iterable already is a list
+     * in which case it will return the same instance.
+     */
+    public static <T> List<T> asList( final Iterable<T> iterable ) {
+        if ( iterable instanceof List ) {
+            return (List<T>) iterable;
+        }
+        final List<T> results = new ArrayList<>();
+        iterable.forEach( results::add );
+        return Collections.unmodifiableList( results );
+    }
+
+    /**
+     * Constructs a new Iterable of batches of a given size. These batches are not created right away but
+     * collected from the base iterable when iterating over it. If the number of items cannot be devided
+     * by the given batchSize the last batch may be smaller than the batchSize requested. Every returned
+     * batch is immutable.
+     * @param iterable The iterable to collect the data from. If null or empty an empty list will be returned.
+     * @param batchSize This batchSize has to be larger tha 0! It determines how many items can be found in each batch.
+     */
+    public static <T> Iterable<List<T>> partition( final Iterable<T> iterable, final int batchSize ) {
+        if ( iterable == null || isEmpty( iterable ) ) {
+            return Collections.emptyList();
+        }
+        if ( batchSize <= 0 ) {
+            throw new IllegalArgumentException( "Lists cannot be partioned with negative batch sizes! [batchsize=" + batchSize + "]" );
+        }
+        return () -> new BatchedIterator<>( iterable, batchSize );
+    }
+
+    /**
+     * Iterator to iterate over all items of a given Iterable in batches of fixed size.
+     * @author Matthias Bender (matthias.bender@freiheit.com)
+     */
+    static class BatchedIterator<T> implements Iterator<List<T>> {
+        private final Iterator<T> data;
+        private final int batchSize;
+
+        /**
+         * Ctor.
+         */
+        public BatchedIterator( final Iterable<T> data, final int batchSize ) {
+            this.data = data.iterator();
+            this.batchSize = batchSize;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return data.hasNext();
+        }
+
+        @Override
+        public List<T> next() {
+            if ( !hasNext() ) {
+                throw new NoSuchElementException();
+            }
+            final List<T> batch = new ArrayList<>( batchSize );
+            for ( int i = 0; i < batchSize && hasNext(); i++ ) {
+                batch.add( data.next() );
+            }
+            return Collections.unmodifiableList( batch );
+        }
+    }
+}

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/util/StringUtils.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/util/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +44,23 @@ public final class StringUtils {
         return str.substring( 0, Math.min( 40, length ) ) + ( length > maxLength
             ? "..."
             : "" );
+    }
+
+    /**
+     * Pads a given String with a given character until it reaches a specific targetlength.
+     */
+    public static String padStart( final String str, final int targetLength, final char filler ) {
+        if ( str == null ) {
+            throw new NullPointerException( "The input string may not be null!" );
+        }
+        if ( str.length() >= targetLength ) {
+            return str;
+        }
+        final StringBuilder result = new StringBuilder();
+        for ( int i = 0; i < targetLength - str.length(); i++ ) {
+            result.append( filler );
+        }
+        return result.append( str ).toString();
     }
 
 }

--- a/core/src/main/java/com/freiheit/fuava/simplebatch/util/Sysprops.java
+++ b/core/src/main/java/com/freiheit/fuava/simplebatch/util/Sysprops.java
@@ -1,22 +1,21 @@
 package com.freiheit.fuava.simplebatch.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Joiner;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
 
 import subdirs.StandardSubdirStrategies;
 import subdirs.SubdirStrategy;
 
 public class Sysprops {
-    
-    private static final ConcurrentLinkedQueue<Prop<?>> ALL_PROPS = new ConcurrentLinkedQueue<Prop<?>>();
+    private static final ConcurrentLinkedQueue<Prop<?>> ALL_PROPS = new ConcurrentLinkedQueue<>();
     
     public abstract static class Prop<T> {
         private final String key;
@@ -52,7 +51,7 @@ public class Sysprops {
 
         @Override
         public List<String> getPossibleStringValues() {
-            return ImmutableList.of( "true", "false" );
+            return Arrays.asList( "true", "false" );
         }
         
         @Override
@@ -61,7 +60,7 @@ public class Sysprops {
         }
         
         public boolean is() {
-            return getOrDefault( v -> "true".equals( v ), defaultValue );
+            return getOrDefault( "true"::equals, defaultValue );
         }
     }
 
@@ -76,7 +75,7 @@ public class Sysprops {
         
         @Override
         public List<String> getPossibleStringValues() {
-            return ImmutableList.of("<any>");
+            return Collections.singletonList( "<any>" );
         }
         
         @Override
@@ -99,7 +98,7 @@ public class Sysprops {
         
         @Override
         public List<String> getPossibleStringValues() {
-            return ImmutableList.of("1, 2, 3, ... ");
+            return Collections.singletonList("1, 2, 3, ... ");
         }
         
         @Override
@@ -108,7 +107,7 @@ public class Sysprops {
         }
         
         public Integer get() {
-            return getOrDefault( v -> Integer.parseInt( v ), defaultValue );
+            return getOrDefault( Integer::parseInt, defaultValue );
         }
     }
 
@@ -128,11 +127,11 @@ public class Sysprops {
         
         @Override
         public List<String> getPossibleStringValues() {
-            return FluentIterable.of( StandardSubdirStrategies.values() ).transform( e -> e.name() ).toList();
+            return Arrays.stream( StandardSubdirStrategies.values() ).map( Enum::name ).collect( Collectors.toList() );
         }
         
         public SubdirStrategy get() {
-            return getOrDefault( v -> StandardSubdirStrategies.getInstance( v ), defaultValue );
+            return getOrDefault( StandardSubdirStrategies::getInstance, defaultValue );
         }
     }
 
@@ -151,17 +150,17 @@ public class Sysprops {
         if ( LOG.isInfoEnabled() ) {
             final StringBuilder sb = new StringBuilder();
             sb.append( "Simplebatch Java Properties. Use -Dpropname=propvalue to control the parameter" ).append( '\n' );
-            for (final Prop<?> p: properties()) {
+            for ( final Prop<?> p: properties() ) {
                 sb
                 .append( '\n' )
-                .append( "# Possible Values: " ).append( Joiner.on( ", " ).join( p.getPossibleStringValues() ) ).append( '\n' )
-                .append( "-D").append( p.getKey() ).append( "=" )
+                .append( "# Possible Values: " ).append( String.join( ", ", p.getPossibleStringValues() ) ).append( '\n' )
+                .append( "-D" ).append( p.getKey() ).append( "=" )
                 .append( p.getDefaultValueString() ).append( '\n' );
             }
             LOG.info( sb.toString() );
         }
     }
-    static final List<Prop<?>> properties() {
-        return ImmutableList.copyOf( Sysprops.ALL_PROPS );
+    static List<Prop<?>> properties() {
+        return Collections.unmodifiableList( new ArrayList<>( ALL_PROPS ) );
     }
 }

--- a/core/src/main/java/subdirs/SubdirStrategy.java
+++ b/core/src/main/java/subdirs/SubdirStrategy.java
@@ -2,6 +2,12 @@ package subdirs;
 
 import java.nio.file.Path;
 
+/**
+ * The SubdirStrategy on how to pick the subsequent directories.
+ */
 public interface SubdirStrategy {
+    /**
+     * Prepends a given filename by a folder to gain the full path of the subdirectory.
+     */
     Path prependSubdir( String filename );        
 }

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/ChainTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/ChainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package com.freiheit.fuava.simplebatch;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.testng.Assert;
@@ -25,7 +26,6 @@ import org.testng.annotations.Test;
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
 import com.freiheit.fuava.simplebatch.fetch.Fetchers;
 import com.freiheit.fuava.simplebatch.processor.Processors;
-import com.google.common.collect.ImmutableList;
 
 /**
  * @author klas.kalass@freiheit.com
@@ -35,17 +35,17 @@ public class ChainTest {
 
     @Test
     public void testChain() {
-        final List<String> results = new ArrayList<String>();
+        final List<String> results = new ArrayList<>();
         final BatchJob<Integer, String> job = BatchJob.<Integer, String> builder()
-            .setFetcher(Fetchers.iterable( ImmutableList.of( 1, 2, 3, 4, 5 ) ) )
+            .setFetcher(Fetchers.iterable( Arrays.asList( 1, 2, 3, 4, 5 ) ) )
             .setProcessor(
-                Processors.<FetchedItem<Integer>, Integer, Integer> singleItemFunction(input -> input.intValue() * 2 )
+                Processors.<FetchedItem<Integer>, Integer, Integer> singleItemFunction(input -> input * 2 )
                 .then( Processors.singleItemFunction(input -> "Wert: " + input ) )
                 .then( Processors.singleItemFunction(input -> {results.add(input); return input;} ) )
             )
             .build();
         job.run();
-        Assert.assertEquals( results, ImmutableList.of("Wert: 2", "Wert: 4", "Wert: 6", "Wert: 8", "Wert: 10") );
+        Assert.assertEquals( results, Arrays.asList( "Wert: 2", "Wert: 4", "Wert: 6", "Wert: 8", "Wert: 10" ) );
     }
 
 }

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/MapBasedBatchDownloader.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/MapBasedBatchDownloader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,12 @@
  */
 package com.freiheit.fuava.simplebatch;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
 import com.freiheit.fuava.simplebatch.processor.RetryingProcessor;
-import com.google.common.collect.ImmutableList;
 
 public final class MapBasedBatchDownloader<I, O> extends RetryingProcessor<FetchedItem<I>, I, O> {
     private final Map<I, O> map;
@@ -32,11 +32,11 @@ public final class MapBasedBatchDownloader<I, O> extends RetryingProcessor<Fetch
 
     @Override
     public List<O> apply( final List<I> arg0 ) {
-        final ImmutableList.Builder<O> b = ImmutableList.builder();
+        final List<O> b = new ArrayList<>( arg0.size() );
         for ( final I i : arg0 ) {
             b.add( map.get( i ) );
         }
-        return b.build();
+        return b;
     }
 
 }

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/TestComposition.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/TestComposition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,28 +16,25 @@
  */
 package com.freiheit.fuava.simplebatch;
 
+import com.freiheit.fuava.simplebatch.processor.Processor;
+import com.freiheit.fuava.simplebatch.processor.Processors;
+import com.freiheit.fuava.simplebatch.result.Result;
+import com.freiheit.fuava.simplebatch.util.CollectionUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
-
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import com.freiheit.fuava.simplebatch.processor.Processor;
-import com.freiheit.fuava.simplebatch.processor.Processors;
-import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Charsets;
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 /**
  * @author tim.lessner@freiheit.com
@@ -63,20 +60,18 @@ public class TestComposition {
     private final String f2String = "exF2";
     private final String f3String = "exF3";
 
-    final ImmutableMap<String, FileContentPair> testFileContentPairs = ImmutableMap.of(
+    final Map<String, FileContentPair> testFileContentPairs = CollectionUtils.asMap(
             f1String, new FileContentPair( exF1, f1String ),
             f2String, new FileContentPair( exF2, f2String ),
-            f3String, new FileContentPair( exF3, f3String )
-            );
+            f3String, new FileContentPair( exF3, f3String ) );
 
-    final ImmutableList<Result<File, File>> nonExistingFiles = ImmutableList.of(
-            asResult( new File( "/tmp/a/a" ) )
-            );
+    final List<Result<File, File>> nonExistingFiles = Collections.singletonList(
+            asResult( new File( "/tmp/a/a" ) ) );
 
     @BeforeClass
     public void makeTestData() throws IOException {
         for ( final FileContentPair fileContentPair : testFileContentPairs.values() ) {
-            try ( Writer fos = new OutputStreamWriter( new FileOutputStream( fileContentPair.file ), Charsets.UTF_8 ) ) {
+            try ( Writer fos = new OutputStreamWriter( new FileOutputStream( fileContentPair.file ), StandardCharsets.UTF_8 ) ) {
                 fos.write( fileContentPair.content );
             }
         }
@@ -110,7 +105,7 @@ public class TestComposition {
         final Processor<File, File, String> compose = makeComposedProcessorFileStringProcessor();
 
         final Iterable<Result<File, String>> processed = compose.process( nonExistingFiles );
-        Assert.assertEquals( Arrays.asList( processed ).size(), 1 );
+        Assert.assertEquals( Collections.singletonList( processed ).size(), 1 );
 
         for ( final Result r : processed ) {
             Assert.assertTrue( r.isFailed(), "Failed result did not fail!" );
@@ -122,12 +117,6 @@ public class TestComposition {
     }
 
     private Processor<File, File, String> makeReadFilesToStringTestProcessor() {
-        return Processors.singleItemFunction( new Function<File, String>() {
-            @Nullable
-            @Override
-            public String apply( final File input ) {
-                return input.getName();
-            }
-        } );
+        return Processors.singleItemFunction( File::getName );
     }
 }

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/TestPersistenceComposition.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/TestPersistenceComposition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,16 +16,18 @@
  */
 package com.freiheit.fuava.simplebatch;
 
-import java.io.File;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import com.freiheit.fuava.simplebatch.processor.Processor;
 import com.freiheit.fuava.simplebatch.processor.Processors;
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * @author tim.lessner@freiheit.com
@@ -34,48 +36,45 @@ public class TestPersistenceComposition {
 
     @Test
     public void testSimpleComposition() {
-        final ImmutableList.Builder<Result<Integer, File>> builder = ImmutableList.<Result<Integer, File>> builder();
-        builder.add( Result.success( 1, new File( "foo" ) ) );
-        builder.add( Result.success( 2, new File( "foo" ) ) );
-        final Processor<Integer, File, String> persistence1 = new Processor<Integer, File, String>() {
-            @Override
-            public Iterable<Result<Integer, String>> process( final Iterable<Result<Integer, File>> iterable ) {
-                final ImmutableList.Builder<Result<Integer, String>> builder = ImmutableList.<Result<Integer, String>> builder();
+        final List<Result<Integer, File>> builder = Arrays.asList(
+                Result.success( 1, new File( "foo" ) ),
+                Result.success( 2, new File( "foo" ) ) );
+        final Processor<Integer, File, String> persistence1 = iterable -> {
+            final List<Result<Integer, String>> builder1 = new ArrayList<>();
 
-                for ( final Result<Integer, File> toTransform : iterable ) {
-                    if ( toTransform.getInput() == 2 ) {
-                        builder.add( Result.success( toTransform.getInput(), toTransform.getOutput().getName() ) );
-
-                    } else {
-                        builder.add( Result.failed( toTransform.getInput(), toTransform.getOutput().getName() ) );
-
-                    }
+            for ( final Result<Integer, File> toTransform : iterable ) {
+                if ( toTransform.getInput() == 2 ) {
+                    builder1.add( Result.success( toTransform.getInput(), toTransform.getOutput().getName() ) );
+                } else {
+                    builder1.add( Result.failed( toTransform.getInput(), toTransform.getOutput().getName() ) );
                 }
-                return builder.build();
             }
+            return builder1;
         };
 
-        final Processor<Integer, String, Object> persistence2 = new Processor<Integer, String, Object>() {
-            @Override
-            public Iterable<Result<Integer, Object>> process( final Iterable<Result<Integer, String>> iterable ) {
-                final ImmutableList.Builder<Result<Integer, Object>> builder = ImmutableList.<Result<Integer, Object>> builder();
-                for ( final Result<Integer, String> toTransform : iterable ) {
-                    if ( toTransform.isFailed() ) {
-                        builder.add( Result.failed( toTransform.getInput(), new String( "hello" ) ) );
-                    } else {
-                        builder.add( Result.success( toTransform.getInput(), new String( "hello" ) ) );
-                    }
+        final Processor<Integer, String, Object> persistence2 = iterable -> {
+            final List<Result<Integer, Object>> builder12 = new ArrayList<>();
+            for ( final Result<Integer, String> toTransform : iterable ) {
+                if ( toTransform.isFailed() ) {
+                    builder12.add( Result.failed( toTransform.getInput(), new String( "hello" ) ) );
+                } else {
+                    builder12.add( Result.success( toTransform.getInput(), new String( "hello" ) ) );
                 }
-                return builder.build();
-
             }
+            return builder12;
         };
 
         final Processor<Integer, File, Object> compose = Processors.compose( persistence2, persistence1 );
-        final Iterable<Result<Integer, Object>> persist = compose.process( builder.build() );
+        final Iterable<Result<Integer, Object>> persist = compose.process( builder );
 
-        final int sizeFailed = FluentIterable.from( persist ).filter( Result::isFailed ).toSet().size();
-        final int sizeSuccess = FluentIterable.from( persist ).filter( Result::isSuccess ).toSet().size();
+        final int sizeFailed = StreamSupport.stream( persist.spliterator(), false )
+                .filter( Result::isFailed )
+                .collect( Collectors.toSet() )
+                .size();
+        final int sizeSuccess = StreamSupport.stream( persist.spliterator(), false )
+                .filter( Result::isSuccess )
+                .collect( Collectors.toSet() )
+                .size();
         Assert.assertEquals( sizeFailed, sizeSuccess, 1 );
     }
 }

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/fetch/HttpPagingFetcherTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/fetch/HttpPagingFetcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +16,21 @@
  */
 package com.freiheit.fuava.simplebatch.fetch;
 
-import java.io.InputStream;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import com.freiheit.fuava.simplebatch.exceptions.FetchFailedException;
 import com.freiheit.fuava.simplebatch.http.HttpFetcher;
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @Test
 public class HttpPagingFetcherTest {
@@ -46,32 +48,29 @@ public class HttpPagingFetcherTest {
     @Test
     public void testFetchLessThanExpected() {
         final DummyHttpFetcher httpFetcher = new DummyHttpFetcher();
-        final ImmutableList<String> fetchedList = ImmutableList.of( "1", "2", "3", "vier" );
+        final List<String> fetchedList = Arrays.asList( "1", "2", "3", "vier" );
         final AtomicLong callCounter = new AtomicLong( 0 );
         final Fetcher<String> fetcher =
-                Fetchers.<String> httpPagingFetcher( httpFetcher,
+                Fetchers.httpPagingFetcher( httpFetcher,
                         ( from, amount ) -> "fetch?from=" + from + "&amount=" + amount,
-                        new Function<InputStream, Iterable<String>>() {
-
-                            @Override
-                            public Iterable<String> apply( final InputStream arg0 ) {
-                                // expected to be called twice
-                                final long c = callCounter.incrementAndGet();
-                                if ( c == 1 ) {
-                                    return fetchedList;
-                                }
-                                Assert.fail( "Should have been called exactly twice" );
-                                return null;
+                        arg0 -> {
+                            // expected to be called twice
+                            final long c = callCounter.incrementAndGet();
+                            if ( c == 1 ) {
+                                return fetchedList;
                             }
-
+                            Assert.fail( "Should have been called exactly twice" );
+                            return null;
                         },
                         0,
                         fetchedList.size() + 1
                         );
 
         final Iterable<Result<FetchedItem<String>, String>> all = fetcher.fetchAll();
-        final ImmutableList<String> result =
-                FluentIterable.from( all ).filter( Result::isSuccess ).transform( Result::getOutput ).toList();
+        final List<String> result = StreamSupport.stream( all.spliterator(), false )
+                .filter( Result::isSuccess )
+                .map( Result::getOutput )
+                .collect( Collectors.toList() );
 
         Assert.assertEquals( result, fetchedList );
         Assert.assertEquals( callCounter.get(), 1, "Expected exactly one call" );
@@ -80,35 +79,32 @@ public class HttpPagingFetcherTest {
     @Test
     public void testFetchOnePageOfPageSize() {
         final DummyHttpFetcher httpFetcher = new DummyHttpFetcher();
-        final ImmutableList<String> fetchedList = ImmutableList.of( "1", "2", "3", "vier" );
+        final List<String> fetchedList = Arrays.asList( "1", "2", "3", "vier" );
         final AtomicLong callCounter = new AtomicLong( 0 );
         final Fetcher<String> fetcher =
-                Fetchers.<String> httpPagingFetcher( httpFetcher,
+                Fetchers.httpPagingFetcher( httpFetcher,
                         ( from, amount ) -> "fetch?from=" + from + "&amount=" + amount,
-                        new Function<InputStream, Iterable<String>>() {
-
-                            @Override
-                            public Iterable<String> apply( final InputStream arg0 ) {
-                                // expected to be called twice
-                                final long c = callCounter.incrementAndGet();
-                                if ( c == 1 ) {
-                                    return fetchedList;
-                                }
-                                if ( c == 2 ) {
-                                    return ImmutableList.of();
-                                }
-                                Assert.fail( "Should have been called exactly twice" );
-                                return null;
+                        arg0 -> {
+                            // expected to be called twice
+                            final long c = callCounter.incrementAndGet();
+                            if ( c == 1 ) {
+                                return fetchedList;
                             }
-
+                            if ( c == 2 ) {
+                                return Collections.emptyList();
+                            }
+                            Assert.fail( "Should have been called exactly twice" );
+                            return null;
                         },
                         0,
                         fetchedList.size()
                         );
 
         final Iterable<Result<FetchedItem<String>, String>> all = fetcher.fetchAll();
-        final ImmutableList<String> result =
-                FluentIterable.from( all ).filter( Result::isSuccess ).transform( Result::getOutput ).toList();
+        final List<String> result = StreamSupport.stream( all.spliterator(), false )
+                .filter( Result::isSuccess )
+                .map( Result::getOutput )
+                .collect( Collectors.toList() );
 
         Assert.assertEquals( result, fetchedList );
         Assert.assertEquals( callCounter.get(), 2, "Expected exactly two calls" );
@@ -117,35 +113,32 @@ public class HttpPagingFetcherTest {
     @Test
     public void testFetchTwoPages() {
         final DummyHttpFetcher httpFetcher = new DummyHttpFetcher();
-        final ImmutableList<String> fetchedList = ImmutableList.of( "1", "2", "3", "vier" );
+        final List<String> fetchedList = Arrays.asList( "1", "2", "3", "vier" );
         final AtomicLong callCounter = new AtomicLong( 0 );
         final Fetcher<String> fetcher =
-                Fetchers.<String> httpPagingFetcher( httpFetcher,
+                Fetchers.httpPagingFetcher( httpFetcher,
                         ( from, amount ) -> "fetch?from=" + from + "&amount=" + amount,
-                        new Function<InputStream, Iterable<String>>() {
-
-                            @Override
-                            public Iterable<String> apply( final InputStream arg0 ) {
-                                // expected to be called twice
-                                final long c = callCounter.incrementAndGet();
-                                if ( c == 1 ) {
-                                    return fetchedList.subList( 0, fetchedList.size() - 1 );
-                                }
-                                if ( c == 2 ) {
-                                    return fetchedList.subList( fetchedList.size() - 1, fetchedList.size() );
-                                }
-                                Assert.fail( "Should have been called exactly twice" );
-                                return null;
+                        arg0 -> {
+                            // expected to be called twice
+                            final long c = callCounter.incrementAndGet();
+                            if ( c == 1 ) {
+                                return fetchedList.subList( 0, fetchedList.size() - 1 );
                             }
-
+                            if ( c == 2 ) {
+                                return fetchedList.subList( fetchedList.size() - 1, fetchedList.size() );
+                            }
+                            Assert.fail( "Should have been called exactly twice" );
+                            return null;
                         },
                         0,
                         fetchedList.size() - 1
                         );
 
         final Iterable<Result<FetchedItem<String>, String>> all = fetcher.fetchAll();
-        final ImmutableList<String> result =
-                FluentIterable.from( all ).filter( Result::isSuccess ).transform( Result::getOutput ).toList();
+        final List<String> result = StreamSupport.stream( all.spliterator(), false )
+                .filter( Result::isSuccess )
+                .map( Result::getOutput )
+                .collect( Collectors.toList() );
 
         Assert.assertEquals( result, fetchedList );
         Assert.assertEquals( callCounter.get(), 2, "Expected exactly two calls" );

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/fsjobs/downloader/CtlDownloaderTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/fsjobs/downloader/CtlDownloaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,25 +16,6 @@
  */
 package com.freiheit.fuava.simplebatch.fsjobs.downloader;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Writer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import com.freiheit.fuava.simplebatch.BatchTestDirectory;
 import com.freiheit.fuava.simplebatch.MapBasedBatchDownloader;
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
@@ -46,15 +27,32 @@ import com.freiheit.fuava.simplebatch.processor.ControlFilePersistenceOutputInfo
 import com.freiheit.fuava.simplebatch.processor.FileWriterAdapter;
 import com.freiheit.fuava.simplebatch.result.Result;
 import com.freiheit.fuava.simplebatch.result.ResultStatistics;
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Test
 public class CtlDownloaderTest {
-
     private static BatchTestDirectory tmp = new BatchTestDirectory( "CtlDownloaderTest" );
     private static Gson GSON = new Gson();
+
     public static <Input, Output> CtlDownloaderJob.BatchFileWritingBuilder<Input, Output> newTestDownloaderBuilder() {
         return new CtlDownloaderJob.BatchFileWritingBuilder<Input, Output>().setConfiguration(
                 new ConfigurationImpl().setDownloadDirPath( tmp.getDownloadsDir() ) );
@@ -101,7 +99,7 @@ public class CtlDownloaderTest {
 
                     @Override
                     public void write( final Writer writer, final List<String> data ) throws IOException {
-                        final String string = Joiner.on( '\n' ).join( data );
+                        final String string = String.join( "\n", data );
                         writer.write( string );
                     }
 
@@ -125,10 +123,10 @@ public class CtlDownloaderTest {
         Assert.assertTrue( expected.exists(), "batch file was not created" );
         Assert.assertTrue( expectedLog.exists(), "log file was not created" );
 
-        final ImmutableList.Builder<String> resultsBuilder = ImmutableList.builder();
+        final List<String> resultsList = new ArrayList<>();
         try ( BufferedReader reader = new BufferedReader( new FileReader( expected ) ) ) {
             while ( reader.ready() ) {
-                resultsBuilder.add( reader.readLine() );
+                resultsList.add( reader.readLine() );
             }
         }
 
@@ -158,7 +156,6 @@ public class CtlDownloaderTest {
         Assert.assertEquals( write6.isSuccess(), true );
         Assert.assertNotNull( write6.getTime() );
 
-        final ImmutableList<String> resultsList = resultsBuilder.build();
         Assert.assertEquals( resultsList, data.values() );
 
         tmp.cleanup();
@@ -167,7 +164,6 @@ public class CtlDownloaderTest {
 
     @Test
     public void testBatchPersistenceNoSubdir() throws FileNotFoundException, IOException {
-
         final String targetFileName = "batch";
         final File expected = tmp.getDownloadsDir().resolve( targetFileName + "_1" ).toFile();
         if ( expected.exists() ) {
@@ -199,7 +195,7 @@ public class CtlDownloaderTest {
 
                     @Override
                     public void write( final Writer writer, final List<String> data ) throws IOException {
-                        final String string = Joiner.on( '\n' ).join( data );
+                        final String string = String.join( "\n", data );
                         writer.write( string );
                     }
                     
@@ -222,10 +218,10 @@ public class CtlDownloaderTest {
         Assert.assertTrue( expected.exists(), "batch file was not created" );
         Assert.assertTrue( expectedLog.exists(), "log file was not created" );
 
-        final ImmutableList.Builder<String> resultsBuilder = ImmutableList.builder();
+        final List<String> resultsList = new ArrayList<>();
         try ( BufferedReader reader = new BufferedReader( new FileReader( expected ) ) ) {
             while ( reader.ready() ) {
-                resultsBuilder.add( reader.readLine() );
+                resultsList.add( reader.readLine() );
             }
         }
 
@@ -233,8 +229,6 @@ public class CtlDownloaderTest {
         final List<String> logLines = Files.readAllLines( Paths.get( expectedLog.toURI() ) );
 
         Assert.assertEquals( logLines.size(), 6 );
-
-        final ImmutableList<String> resultsList = resultsBuilder.build();
         Assert.assertEquals( resultsList, data.values() );
 
         tmp.cleanup();

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/fsjobs/importer/CtlImporterPathAndConcurrencyTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/fsjobs/importer/CtlImporterPathAndConcurrencyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,29 +16,6 @@
  */
 package com.freiheit.fuava.simplebatch.fsjobs.importer;
 
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Writer;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
 import com.freiheit.fuava.simplebatch.BatchTestDirectory;
 import com.freiheit.fuava.simplebatch.MapBasedBatchDownloader;
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
@@ -50,20 +27,37 @@ import com.freiheit.fuava.simplebatch.processor.Processor;
 import com.freiheit.fuava.simplebatch.processor.RetryingProcessor;
 import com.freiheit.fuava.simplebatch.result.Result;
 import com.freiheit.fuava.simplebatch.result.ResultStatistics;
-import com.google.common.base.Charsets;
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
+import com.freiheit.fuava.simplebatch.util.CollectionUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 @Test
 public class CtlImporterPathAndConcurrencyTest {
 
-    private final Map<Integer, String> data = ImmutableMap.of(
+    private final Map<Integer, String> data = CollectionUtils.asMap(
             1, "eins",
             2, "zwei",
             3, "drei",
@@ -75,91 +69,91 @@ public class CtlImporterPathAndConcurrencyTest {
             
             {testCase( "Success" )
                 .successProcessor()
-                .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
             
             {testCase( "Fail All" )
                     .failAllProcessor()
-                    .expect( BatchTestDirectory.FAILS, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                    .expect( BatchTestDirectory.FAILS, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
             
             {testCase( "Fail Some" )
                     .failSomeProcessor()
-                    .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                    .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
             
             {testCase( "Fail Batch")
                 .failBatchProcessor()
-                .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
             
             {testCase( "Success File Concurrent" )
                     .successProcessor()
                     .numConcurrentFiles( 2 )
                     .numConcurrentData( 1 )
-                    .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                    .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
             
             {testCase( "Fail All File Concurrent" )
                     .failAllProcessor()
                     .numConcurrentFiles( 2 )
                     .numConcurrentData( 1 )
-                    .expect( BatchTestDirectory.FAILS, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                    .expect( BatchTestDirectory.FAILS, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
             
             {testCase( "Fail Some File Concurrent" )
                     .failSomeProcessor()
                     .numConcurrentFiles( 2 )
                     .numConcurrentData( 1 )
-                    .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                    .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
             
             {testCase( "Fail Batch File Concurrent")
                 .failBatchProcessor()
                 .numConcurrentFiles( 2 )
                 .numConcurrentData( 1 )
-                .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
            
             {testCase( "Success File And Data Concurrent" )
                 .successProcessor()
                 .numConcurrentFiles( 2 )
                 .numConcurrentData( 1 )
-                .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
                 
                 {testCase( "Fail All File And Data Concurrent" )
                         .failAllProcessor()
                         .numConcurrentFiles( 2 )
                         .numConcurrentData( 2 )
-                        .expect( BatchTestDirectory.FAILS, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                        .expect( BatchTestDirectory.FAILS, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
                 
                 {testCase( "Fail Some File And Data Concurrent" )
                         .failSomeProcessor()
                         .numConcurrentFiles( 2 )
                         .numConcurrentData( 2 )
-                        .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                        .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
                 
                 {testCase( "Fail Batch File And Data Concurrent")
                     .failBatchProcessor()
                     .numConcurrentFiles( 2 )
                     .numConcurrentData( 2 )
-                    .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                    .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
                 
                 {testCase( "Success Data Concurrent" )
                     .successProcessor()
                     .numConcurrentFiles( 1 )
                     .numConcurrentData( 1 )
-                    .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                    .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
                 
                 {testCase( "Fail All Data Concurrent" )
                         .failAllProcessor()
                         .numConcurrentFiles( 1 )
                         .numConcurrentData( 2 )
-                        .expect( BatchTestDirectory.FAILS, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                        .expect( BatchTestDirectory.FAILS, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
                 
                 {testCase( "Fail Some Data Concurrent" )
                         .failSomeProcessor()
                         .numConcurrentFiles( 1 )
                         .numConcurrentData( 2 )
-                        .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
+                        .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )},
                 
                 {testCase( "Fail Batch Data Concurrent")
                     .failBatchProcessor()
                     .numConcurrentFiles( 1 )
                     .numConcurrentData( 2 )
-                    .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( "inst_01-1.tmp", "inst_01-2.tmp" ) )}
+                    .expect( BatchTestDirectory.ARCHIVE, CollectionUtils.asSet( "inst_01-1.tmp", "inst_01-2.tmp" ) )}
 
         };
     }
@@ -172,7 +166,7 @@ public class CtlImporterPathAndConcurrencyTest {
         
         for (final ExpectedDirState state : testCase.getExpectedDirsAfterDownload()) {
             final Set<String> expectedNames = state.getExpectedNames();
-            final Multimap<String, SBFile> impFiles = listFilesInDir( tmp, state.getDir() );
+            final Map<String, List<SBFile>> impFiles = listFilesInDir( tmp, state.getDir() );
             Assert.assertEquals( impFiles.keySet(), expectedNames, "Wrong State after Download in " + state.dir   );
         }
         
@@ -185,7 +179,7 @@ public class CtlImporterPathAndConcurrencyTest {
 
         for (final ExpectedDirState state : testCase.getExpectedDirs()) {
             final Set<String> expectedNames = state.getExpectedNames();
-            final Multimap<String, SBFile> impFiles = listFilesInDir( tmp, state.getDir() );
+            final Map<String, List<SBFile>> impFiles = listFilesInDir( tmp, state.getDir() );
             Assert.assertEquals( impFiles.keySet(), expectedNames, "Wrong State after Import in " + state.dir  );
         }
 
@@ -250,7 +244,7 @@ public class CtlImporterPathAndConcurrencyTest {
     static final class TestCase {
         private final String name;
         
-        private Map<Integer, String> data = ImmutableMap.of();
+        private Map<Integer, String> data = Collections.emptyMap();
         private int numConcurrentFiles = 1;
         private int numConcurrentData = 1;
         private int fileBatchSize = 1;
@@ -377,15 +371,15 @@ public class CtlImporterPathAndConcurrencyTest {
         return new TestCase( name )
                 .data( data )
                 .fileBatchSize( 2 )
-                .expectAfterDownload( BatchTestDirectory.ARCHIVE, ImmutableSet.of( ) )
-                .expectAfterDownload( BatchTestDirectory.FAILS, ImmutableSet.of( ) )
-                .expectAfterDownload( BatchTestDirectory.PROCESSING, ImmutableSet.of( ) )
-                .expectAfterDownload( BatchTestDirectory.DOWNLOADS, ImmutableSet.of( "1.tmp", "2.tmp" ) )
+                .expectAfterDownload( BatchTestDirectory.ARCHIVE, Collections.emptySet() )
+                .expectAfterDownload( BatchTestDirectory.FAILS, Collections.emptySet() )
+                .expectAfterDownload( BatchTestDirectory.PROCESSING, Collections.emptySet() )
+                .expectAfterDownload( BatchTestDirectory.DOWNLOADS, CollectionUtils.asSet( "1.tmp", "2.tmp" ) )
                 // at least one of those will be overridden
-                .expect( BatchTestDirectory.ARCHIVE, ImmutableSet.of( ) )
-                .expect( BatchTestDirectory.FAILS, ImmutableSet.of( ) )
-                .expect( BatchTestDirectory.PROCESSING, ImmutableSet.of( ) )
-                .expect( BatchTestDirectory.DOWNLOADS, ImmutableSet.of(  ) )
+                .expect( BatchTestDirectory.ARCHIVE, Collections.emptySet() )
+                .expect( BatchTestDirectory.FAILS, Collections.emptySet() )
+                .expect( BatchTestDirectory.PROCESSING, Collections.emptySet() )
+                .expect( BatchTestDirectory.DOWNLOADS, Collections.emptySet() )
                 ;
     }
     
@@ -401,23 +395,23 @@ public class CtlImporterPathAndConcurrencyTest {
     }
 
     private void assertIsEmpty( final Path dir ) throws IOException {
-        final Multimap<String, SBFile> files = listFilesInDir( dir );
+        final Map<String, List<SBFile>> files = listFilesInDir( dir );
         Assert.assertTrue( files.isEmpty(), "Directory " + dir + " not empty. It contains files " + files );
     }
 
-    private Multimap<String, SBFile> listFilesInDir( final BatchTestDirectory cfg, final String dir ) throws IOException {
+    private Map<String, List<SBFile>> listFilesInDir( final BatchTestDirectory cfg, final String dir ) throws IOException {
         return listFilesInDir( cfg.getTestDirBase().resolve( dir ) );
     }
     
-    private Multimap<String, SBFile> listFilesInDir( final Path dir ) throws IOException {
+    private Map<String, List<SBFile>> listFilesInDir( final Path dir ) throws IOException {
         if ( !dir.toFile().exists() ) {
-            return ImmutableListMultimap.<String, SBFile>builder().build();
+            return Collections.emptyMap();
         }
-        final ImmutableList.Builder<SBFile> b = ImmutableList.builder();
+        final List<SBFile> files = new ArrayList<>();
         Files.walkFileTree( dir,  new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile( final Path file, final BasicFileAttributes attrs ) throws IOException {
-                b.add( new SBFile( file ) );
+                files.add( new SBFile( file ) );
                 return FileVisitResult.CONTINUE;
             }
 
@@ -427,8 +421,7 @@ public class CtlImporterPathAndConcurrencyTest {
             }
 
         });
-        final List<SBFile> files = b.build();
-        return Multimaps.index( files, f -> f.getDataName() );
+        return files.stream().collect( Collectors.groupingBy( SBFile::getDataName ) );
     }
 
     private CtlImporterJob.Builder<String> createImporterJob( final BatchTestDirectory tmp, final Processor<FetchedItem<String>, String, String> processor ) {
@@ -439,20 +432,16 @@ public class CtlImporterPathAndConcurrencyTest {
                         .setFailedDirPath( tmp.getFailsDir() )
                         .setProcessingDirPath( tmp.getProcessingDir() ) 
                 )
-                .setFileInputStreamReader( new Function<InputStream, Iterable<String>>() {
-
-                        @Override
-                        public Iterable<String> apply( final InputStream input ) {
-                            try {
-                                try ( BufferedReader ir =
-                                        new BufferedReader( new InputStreamReader( input, Charsets.UTF_8 ) ) ) {
-                                    return ImmutableList.of( ir.readLine() );
-                                }
-                            } catch ( final IOException e ) {
-                                throw new RuntimeException( e );
-                            }
+                .setFileInputStreamReader( input -> {
+                    try {
+                        try ( BufferedReader ir =
+                                new BufferedReader( new InputStreamReader( input, StandardCharsets.UTF_8 ) ) ) {
+                            return Collections.singletonList( ir.readLine() );
                         }
-                    } 
+                    } catch ( final IOException e ) {
+                        throw new RuntimeException( e );
+                    }
+                }
                 )
                 .setContentProcessor( processor )
                 ;
@@ -470,7 +459,7 @@ public class CtlImporterPathAndConcurrencyTest {
 
                             @Override
                             public void write( final Writer writer, final List<String> data ) throws IOException {
-                                final String string = Joiner.on( '\n' ).join( data );
+                                final String string = String.join( "\n", data );
                                 writer.write( string );
                             }
 

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/processor/RetryingProcessorTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/processor/RetryingProcessorTest.java
@@ -1,15 +1,16 @@
 package com.freiheit.fuava.simplebatch.processor;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.freiheit.fuava.simplebatch.result.Result;
+import com.freiheit.fuava.simplebatch.util.CollectionUtils;
+import com.freiheit.fuava.simplebatch.util.IterableUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class RetryingProcessorTest {
   @Test
@@ -18,7 +19,7 @@ public class RetryingProcessorTest {
        Assert.assertEquals( result.size(), 3 );
        Assert.assertTrue( result.stream().allMatch( Result::isSuccess ) );
        Assert.assertTrue( result.stream().noneMatch( Result::isFailed) );
-       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), ImmutableSet.of( 1, 2, 3 ) );
+       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), CollectionUtils.asSet( 1, 2, 3 ) );
   }
 
   @Test
@@ -27,7 +28,7 @@ public class RetryingProcessorTest {
        Assert.assertEquals( result.size(), 3 );
        Assert.assertTrue( result.stream().allMatch( Result::isSuccess ) );
        Assert.assertTrue( result.stream().noneMatch( Result::isFailed) );
-       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), ImmutableSet.of( 1, 2, 3 ) );
+       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), CollectionUtils.asSet( 1, 2, 3 ) );
   }
 
   @Test
@@ -36,7 +37,7 @@ public class RetryingProcessorTest {
        Assert.assertEquals( result.size(), 3 );
        Assert.assertTrue( result.stream().allMatch( Result::isFailed ) );
        Assert.assertTrue( result.stream().noneMatch( Result::isSuccess) );
-       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), ImmutableSet.of() );
+       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), Collections.emptySet() );
   }
 
   @Test
@@ -45,19 +46,19 @@ public class RetryingProcessorTest {
        Assert.assertEquals( result.size(), 3 );
        Assert.assertTrue( result.stream().anyMatch( Result::isSuccess ) );
        Assert.assertTrue( result.stream().anyMatch( Result::isFailed) );
-       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), ImmutableSet.of( 1, 3 ) );
+       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), CollectionUtils.asSet( 1, 3 ) );
   }
 
-  private List<Result<Integer, Integer>> execute(final Function<List<Integer>, List<Integer>> func, final int...input) {
-      return ImmutableList.copyOf( new RetryingFunctionProcessor<Integer, Integer, Integer>( func )
-      .process( prepare( input ) ) );
+  private List<Result<Integer, Integer>> execute( final Function<List<Integer>, List<Integer>> func, final int...input) {
+      return IterableUtils.asList( new RetryingFunctionProcessor<Integer, Integer, Integer>( func )
+              .process( prepare( input ) ) );
   }
        
   private Iterable<Result<Integer, Integer>> prepare(final int... input) {
-      final ImmutableList.Builder<Result<Integer, Integer>> b = ImmutableList.builder();
-      for (int i = 0; i < input.length ; i++) {
-          b.add( Result.success( input[i], input[i] ) );
+      final List<Result<Integer, Integer>> b = new ArrayList<>();
+      for ( int value : input ) {
+          b.add( Result.success( value, value ) );
       }
-      return b.build();
+      return b;
   }
 }

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/processor/RetryingResultProcessorTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/processor/RetryingResultProcessorTest.java
@@ -19,23 +19,26 @@
 
 package com.freiheit.fuava.simplebatch.processor;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import com.freiheit.fuava.simplebatch.result.Result;
+import com.freiheit.fuava.simplebatch.util.CollectionUtils;
+import com.freiheit.fuava.simplebatch.util.IterableUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class RetryingResultProcessorTest {
   @Test
   public void testNoFailures() {
-       final List<Result<Integer, Integer>> result = execute(items -> extractOutputs(items), 1, 2, 3);
+       final List<Result<Integer, Integer>> result = execute( this::extractOutputs, 1, 2, 3);
        Assert.assertEquals( result.size(), 3 );
        Assert.assertTrue( result.stream().allMatch( Result::isSuccess ) );
        Assert.assertTrue( result.stream().noneMatch( Result::isFailed) );
-       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), ImmutableSet.of( 1, 2, 3 ) );
+       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), CollectionUtils.asSet( 1, 2, 3 ) );
   }
 
   @Test
@@ -44,7 +47,7 @@ public class RetryingResultProcessorTest {
        Assert.assertEquals( result.size(), 3 );
        Assert.assertTrue( result.stream().allMatch( Result::isSuccess ) );
        Assert.assertTrue( result.stream().noneMatch( Result::isFailed) );
-       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), ImmutableSet.of( 1, 2, 3 ) );
+       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), CollectionUtils.asSet( 1, 2, 3 ) );
   }
 
   @Test
@@ -53,7 +56,7 @@ public class RetryingResultProcessorTest {
        Assert.assertEquals( result.size(), 3 );
        Assert.assertTrue( result.stream().allMatch( Result::isFailed ) );
        Assert.assertTrue( result.stream().noneMatch( Result::isSuccess) );
-       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), ImmutableSet.of() );
+       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), Collections.emptySet() );
   }
 
   @Test
@@ -62,20 +65,19 @@ public class RetryingResultProcessorTest {
        Assert.assertEquals( result.size(), 3 );
        Assert.assertTrue( result.stream().anyMatch( Result::isSuccess ) );
        Assert.assertTrue( result.stream().anyMatch( Result::isFailed ) );
-       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), ImmutableSet.of( 1, 3 ) );
+       Assert.assertEquals( result.stream().filter( Result::isSuccess ).map( Result::getOutput).collect( Collectors.toSet() ), CollectionUtils.asSet( 1, 3 ) );
   }
 
-  private List<Result<Integer, Integer>> execute(final Function<List<Result<Integer, Integer>>, List<Integer>> func, final int...input) {
-      return ImmutableList.copyOf( new RetryingResultFunctionProcessor<Integer, Integer, Integer>( func )
-      .process( prepare( input ) ) );
+  private List<Result<Integer, Integer>> execute( final Function<List<Result<Integer, Integer>>, List<Integer>> func, final int...input) {
+      return IterableUtils.asList( new RetryingResultFunctionProcessor<>( func ).process( prepare( input ) ) );
   }
 
   private Iterable<Result<Integer, Integer>> prepare(final int... input) {
-      final ImmutableList.Builder<Result<Integer, Integer>> b = ImmutableList.builder();
-      for (int i = 0; i < input.length ; i++) {
-          b.add( Result.success( input[i], input[i] ) );
+      final List<Result<Integer, Integer>> b = new ArrayList<>();
+      for ( int value : input ) {
+          b.add( Result.success( value, value ) );
       }
-      return b.build();
+      return b;
   }
 
   private List<Integer> extractOutputs( final List<Result<Integer, Integer>> items ) {

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/processor/TimeLoggingProcessorTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/processor/TimeLoggingProcessorTest.java
@@ -1,19 +1,19 @@
 package com.freiheit.fuava.simplebatch.processor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.freiheit.fuava.simplebatch.util.CollectionUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.freiheit.fuava.simplebatch.processor.TimeLoggingProcessor.Counts;
 import com.freiheit.fuava.simplebatch.result.Result;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 public class TimeLoggingProcessorTest {
-
     @DataProvider
     public Object[][] durationAsStringsTestData() {
         return new Object[][] {
@@ -83,8 +83,8 @@ public class TimeLoggingProcessorTest {
         final TimeLoggingProcessor<String, String, String> processor = wrap( new AddA() );
         assertResults( processor.process( data( "2", "3" ) ), "2a", "3a" );
         final Map<String, Counts> counts = processor.getCurrentCounts();
-        Assert.assertEquals( ImmutableSet.copyOf( counts.keySet() ),
-                ImmutableSet.of( processor.getStageIdTotal(), processor.getStageIdPrepare(), "Stage 01" ) );
+        Assert.assertEquals( counts.keySet(),
+                CollectionUtils.asSet( processor.getStageIdTotal(), processor.getStageIdPrepare(), "Stage 01" ) );
 
         assertCountsItems( processor, counts, 2 );
 
@@ -107,8 +107,8 @@ public class TimeLoggingProcessorTest {
 
         assertResults( processor.process( data( "2", "3" ) ), "2abcd", "3abcd" );
         final Map<String, Counts> counts = processor.getCurrentCounts();
-        Assert.assertEquals( ImmutableSet.copyOf( counts.keySet() ),
-                ImmutableSet.of( processor.getStageIdTotal(), processor.getStageIdPrepare(), "Stage 01", "Stage 02", "Stage 03",
+        Assert.assertEquals( counts.keySet(),
+                CollectionUtils.asSet( processor.getStageIdTotal(), processor.getStageIdPrepare(), "Stage 01", "Stage 02", "Stage 03",
                         "Stage 04" ) );
         assertCountsItems( processor, counts, 2 );
     }
@@ -132,8 +132,8 @@ public class TimeLoggingProcessorTest {
 
         assertResults( processor.process( data( "2", "3" ) ), "2abcd", "3abcd" );
         final Map<String, Counts> counts = processor.getCurrentCounts();
-        Assert.assertEquals( ImmutableSet.copyOf( counts.keySet() ),
-                ImmutableSet.of( processor.getStageIdTotal(), processor.getStageIdPrepare(), "Stage 01", "Stage 02", "Stage 03",
+        Assert.assertEquals( counts.keySet(),
+                CollectionUtils.asSet( processor.getStageIdTotal(), processor.getStageIdPrepare(), "Stage 01", "Stage 02", "Stage 03",
                         "Stage 04" ) );
         assertCountsItems( processor, counts, 2 );
     }
@@ -150,11 +150,11 @@ public class TimeLoggingProcessorTest {
     }
 
     private Iterable<Result<String, String>> data( final String... values ) {
-        final ImmutableList.Builder<Result<String, String>> b = ImmutableList.builder();
+        final List<Result<String, String>> b = new ArrayList<>();
         for ( final String v : values ) {
             b.add( Result.success( v, v ) );
         }
-        return b.build();
+        return b;
     }
 
     private TimeLoggingProcessor<String, String, String> wrap( final Processor<String, String, String> addA ) {

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/result/ResultTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/result/ResultTest.java
@@ -1,12 +1,11 @@
 package com.freiheit.fuava.simplebatch.result;
 
-import java.util.List;
-
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.stream.StreamSupport;
 
 public class ResultTest {
     
@@ -25,12 +24,13 @@ public class ResultTest {
     @Test( dataProvider = "dataProviderSuccessMap" )
     public void testSuccessMapping(final Result<String, String> initialResult, final Integer expectedOutput, final boolean expectedSuccess, final boolean expectNewFailure) {
         final List<String> initialMessages = initialResult.getAllMessages();
-        final Result<String, Integer> result = initialResult.map( v -> Integer.parseInt(v) );
+        final Result<String, Integer> result = initialResult.map( Integer::parseInt );
         Assert.assertEquals( result.isSuccess(), expectedSuccess );
         Assert.assertEquals( result.isFailed(), !expectedSuccess );
         Assert.assertEquals( result.getOutput(), expectedOutput );
         if (expectNewFailure) {
-            Assert.assertEquals( Iterables.size( result.getFailureMessages() ), Iterables.size( initialMessages ) + 1 );
+            Assert.assertEquals( StreamSupport.stream( result.getFailureMessages().spliterator(), false ).count(),
+                    (long) initialMessages.size() + 1 );
         } else {
             Assert.assertEquals( result.getFailureMessages(), initialMessages );
         }

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/util/CollectionUtils.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/util/CollectionUtils.java
@@ -1,0 +1,41 @@
+package com.freiheit.fuava.simplebatch.util;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class CollectionUtils {
+    @SafeVarargs
+    public static <T> Set<T> asSet( final T item1, final T ... items ) {
+        final Set<T> result = new LinkedHashSet<>( items.length + 1 );
+        result.add( item1 );
+        Collections.addAll( result, items );
+        return result;
+    }
+
+    public static <K, V> Map<K, V> asMap(
+            final K k1, final V v1,
+            final K k2, final V v2,
+            final K k3, final V v3 ) {
+        final Map<K, V> result = new LinkedHashMap<>( 4 );
+        result.put( k1, v1 );
+        result.put( k2, v2 );
+        result.put( k3, v3 );
+        return result;
+    }
+
+    public static <K, V> Map<K, V> asMap(
+            final K k1, final V v1,
+            final K k2, final V v2,
+            final K k3, final V v3,
+            final K k4, final V v4 ) {
+        final Map<K, V> result = new LinkedHashMap<>( 4 );
+        result.put( k1, v1 );
+        result.put( k2, v2 );
+        result.put( k3, v3 );
+        result.put( k4, v4 );
+        return result;
+    }
+}

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/util/IterableUtilsTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/util/IterableUtilsTest.java
@@ -1,0 +1,83 @@
+package com.freiheit.fuava.simplebatch.util;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests the {@link IterableUtils}.
+ */
+public class IterableUtilsTest {
+    @Test( dataProvider = "testIsEmptyDeterminesEmptyness" )
+    public void testIsEmptyDeterminesEmptyness( final Iterable<String> input, boolean output ) {
+        if ( output ) {
+            assertTrue( IterableUtils.isEmpty( input ), "Expected the iterable to be empty!" );
+        } else {
+            assertFalse( IterableUtils.isEmpty( input ), "Expected the iterable to be nonempty!" );
+        }
+    }
+
+    @DataProvider( name = "testIsEmptyDeterminesEmptyness" )
+    public Object[][] provideEmptynessData() {
+        return new Object[][] {
+                { Collections.emptyList(), true },
+                { Collections.emptySet(), true },
+                { ( Iterable<String> ) Collections::emptyIterator, true },
+                { Collections.singleton( "123" ), false },
+                { Collections.singletonList( "123" ), false },
+                { ( Iterable<String> ) () -> Collections.singletonList( "123" ).iterator(), false },
+        };
+    }
+
+    @Test
+    public void testAsListConvertsIterableToList() {
+        assertEquals( IterableUtils.asList( Collections.emptyList() ), Collections.emptyList() );
+        assertEquals( IterableUtils.asList( Collections.singletonList( "hello" ) ), Collections.singletonList( "hello" ) );
+        assertEquals( IterableUtils.asList( Collections.emptySet() ), Collections.emptyList() );
+        assertEquals( IterableUtils.asList( Collections.singleton( "hello" ) ), Collections.singletonList( "hello" ) );
+        assertEquals( IterableUtils.asList( Collections::emptyIterator ), Collections.emptyList() );
+        assertEquals( IterableUtils.asList( () -> Collections.singletonList( "hello" ).iterator() ), Collections.singletonList( "hello" ) );
+    }
+
+    @Test
+    public void testPartitionReturnsEmptyIterableOnNullOrEmpty() {
+        assertEquals( IterableUtils.partition( null, 5 ), Collections.emptyList() );
+        assertEquals( IterableUtils.partition( Collections.emptySet(), 5 ), Collections.emptyList() );
+        assertEquals( IterableUtils.partition( Collections::emptyIterator, 5 ), Collections.emptyList() );
+    }
+
+    @Test( expectedExceptions = { IllegalArgumentException.class } )
+    public void testPartitionThrowsExceptionIfBatchSizeTooSmall() {
+        IterableUtils.partition( Collections.singleton( "TestEntry" ), -5 );
+    }
+
+    @Test
+    public void testPartitionCreatesBatches() {
+        final List<Integer> items = Arrays.asList( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 );
+        final Iterable<List<Integer>> batches = IterableUtils.partition( items, 3 );
+        assertEquals( IterableUtils.asList( batches ), Arrays.asList(
+                Arrays.asList( 1, 2, 3 ),
+                Arrays.asList( 4, 5, 6 ),
+                Arrays.asList( 7, 8, 9 ),
+                Collections.singletonList( 10 )
+        ) );
+    }
+
+    @Test
+    public void testPartitionCreatesBatchesExactly() {
+        final List<Integer> items = Arrays.asList( 1, 2, 3, 4, 5, 6, 7, 8, 9 );
+        final Iterable<List<Integer>> batches = IterableUtils.partition( items, 3 );
+        assertEquals( IterableUtils.asList( batches ), Arrays.asList(
+                Arrays.asList( 1, 2, 3 ),
+                Arrays.asList( 4, 5, 6 ),
+                Arrays.asList( 7, 8, 9 )
+        ) );
+    }
+}

--- a/core/src/test/java/com/freiheit/fuava/simplebatch/util/StringUtilsTest.java
+++ b/core/src/test/java/com/freiheit/fuava/simplebatch/util/StringUtilsTest.java
@@ -1,0 +1,30 @@
+package com.freiheit.fuava.simplebatch.util;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests the {@link StringUtils}.
+ */
+public class StringUtilsTest {
+    @Test( expectedExceptions = NullPointerException.class )
+    public void testPadStartThrowsExceptionIfStringIsNull() {
+        StringUtils.padStart( null, 5, '#');
+    }
+
+    @Test
+    public void testPadStartReturnsInputIfInputIsLongerThanRequired() {
+        assertEquals( StringUtils.padStart( "12345", 5, '#' ), "12345" );
+        assertEquals( StringUtils.padStart( "1234567", 5, '#' ), "1234567" );
+    }
+
+    @Test
+    public void testPadStartPrepandsCharacters() {
+        assertEquals( StringUtils.padStart( "1234", 5, '#' ), "#1234" );
+        assertEquals( StringUtils.padStart( "123", 5, '#' ), "##123" );
+        assertEquals( StringUtils.padStart( "12", 5, '#' ), "###12" );
+        assertEquals( StringUtils.padStart( "1", 5, '#' ), "####1" );
+        assertEquals( StringUtils.padStart( "", 5, '#' ), "#####" );
+    }
+}

--- a/core/src/test/java/subdirs/StandardSubdirStrategiesTest.java
+++ b/core/src/test/java/subdirs/StandardSubdirStrategiesTest.java
@@ -2,19 +2,17 @@ package subdirs;
 
 import java.time.LocalDateTime;
 
+import com.freiheit.fuava.simplebatch.util.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Strings;
-
 public class StandardSubdirStrategiesTest {
-
     @DataProvider
     public Object[][] testStrategies() {
         final LocalDateTime now = LocalDateTime.now();
-        final String hours = Strings.padStart( Integer.toString( now.getHour() ) , 2, '0' );
-        final String minutes = Strings.padStart( Integer.toString( now.getMinute() ) , 2, '0' );
+        final String hours = StringUtils.padStart( Integer.toString( now.getHour() ) , 2, '0' );
+        final String minutes = StringUtils.padStart( Integer.toString( now.getMinute() ) , 2, '0' );
         return new Object[][] {
             { StandardSubdirStrategies.NONE, "foo.txt", "foo.txt" },
             { StandardSubdirStrategies.NONE, "1.ctl", "1.ctl" },

--- a/sftplib/build.gradle
+++ b/sftplib/build.gradle
@@ -8,7 +8,6 @@ jar {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:18.0'
     compile 'org.json:json:20141113'
     compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'commons-configuration:commons-configuration:1.10'

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/RemoteClient.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/RemoteClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/RemoteConfigurationImpl.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/RemoteConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,8 +25,6 @@ import com.freiheit.fuava.simplebatch.util.FileUtils;
  * @author dmitrijs.barbarins@freiheit.com
  */
 public class RemoteConfigurationImpl implements RemoteConfiguration {
-
-
     private final String remoteFilesIncomingFolder;
     private final String remoteProcessingFolder;
     private final String remoteSkippedFolder;

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/RemoteConfigurationWithPlaceholderImpl.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/RemoteConfigurationWithPlaceholderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,8 @@ package com.freiheit.fuava.sftp;
 
 import com.freiheit.fuava.sftp.util.RemoteConfiguration;
 import com.freiheit.fuava.simplebatch.util.FileUtils;
-import com.google.common.base.Preconditions;
+
+import java.util.Objects;
 
 /**
  * The SFTP-Server Configuration.
@@ -26,8 +27,6 @@ import com.google.common.base.Preconditions;
  * @author dmitrijs.barbarins@freiheit.com
  */
 public class RemoteConfigurationWithPlaceholderImpl implements RemoteConfiguration {
-
-
     private final String remoteFilesIncomingFolder;
     private final String remoteProcessingFolder;
     private final String remoteSkippedFolder;
@@ -49,9 +48,9 @@ public class RemoteConfigurationWithPlaceholderImpl implements RemoteConfigurati
             final String remoteProcessingFolder,
             final String remoteSkippedFolder,
             final String remoteArchivedFolder) {
-        Preconditions.checkNotNull( remoteFilesIncomingFolder, "remoteIncomingFolder must be provided, but was null" );
-        Preconditions.checkNotNull( remoteSkippedFolder, "remoteSkippedFolder must be provided, but was null" );
-        Preconditions.checkNotNull( remoteArchivedFolder, "remoteArchivedFolder must be provided, but was null" );
+        Objects.requireNonNull( remoteFilesIncomingFolder, "remoteIncomingFolder must be provided, but was null" );
+        Objects.requireNonNull( remoteSkippedFolder, "remoteSkippedFolder must be provided, but was null" );
+        Objects.requireNonNull( remoteArchivedFolder, "remoteArchivedFolder must be provided, but was null" );
         this.remoteArchivedFolder = FileUtils.substitutePlaceholder( remoteArchivedFolder );
         this.remoteFilesIncomingFolder = FileUtils.substitutePlaceholder( remoteFilesIncomingFolder );
         this.remoteProcessingFolder = remoteProcessingFolder == null

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/RemoteFileStatus.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/RemoteFileStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpClient.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,24 +16,23 @@
  */
 package com.freiheit.fuava.sftp;
 
-import java.io.InputStream;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.annotation.CheckForNull;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.LoggerFactory;
 import com.freiheit.fuava.sftp.util.ConvertUtil;
 import com.freiheit.fuava.sftp.util.FileType;
 import com.freiheit.fuava.sftp.util.FilenameUtil;
-import com.google.common.base.Preconditions;
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.jcraft.jsch.SftpException;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.CheckForNull;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Simple SFTP client.
@@ -372,12 +371,11 @@ public class SftpClient implements RemoteClient {
         }
 
         public SftpClient createSftpClient() {
-            Preconditions.checkNotNull( this.host, "You have to provide a host" );
-            Preconditions.checkNotNull( this.port, "You have to provide a port" );
-            Preconditions.checkNotNull( this.username, "You have to provide a username" );
-            if ( this.strictHostkeyChecking == StrictHostkeyChecking.OFF ) {
-                Preconditions.checkArgument( this.knownHostsInputStream == null,
-                    "You disabled StrictHostKeyChecking but provided knownHosts (which would have no effect)." );
+            Objects.requireNonNull( this.host, "You have to provide a host" );
+            Objects.requireNonNull( this.port, "You have to provide a port" );
+            Objects.requireNonNull( this.username, "You have to provide a username" );
+            if ( this.strictHostkeyChecking == StrictHostkeyChecking.OFF && knownHostsInputStream != null ) {
+                throw new IllegalArgumentException( "You disabled StrictHostKeyChecking but provided knownHosts (which would have no effect)." );
             }
             return new SftpClient( host, port, username, password, socketTimeoutMs, knownHostsInputStream, strictHostkeyChecking );
         }

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpDownloaderJob.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpDownloaderJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,6 @@
  */
 package com.freiheit.fuava.sftp;
 
-import org.apache.commons.lang.StringUtils;
 import com.freiheit.fuava.sftp.util.FileType;
 import com.freiheit.fuava.sftp.util.RemoteConfiguration;
 import com.freiheit.fuava.simplebatch.BatchJob;
@@ -35,7 +34,6 @@ import com.freiheit.fuava.simplebatch.processor.TimeLoggingProcessor;
  * @author Thomas Ostendorf (thomas.ostendorf@freiheit.com)
  */
 public class SftpDownloaderJob {
-
     private SftpDownloaderJob() {
     }
 

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpDownloadingFileWriterAdapter.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpDownloadingFileWriterAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@ import com.freiheit.fuava.sftp.util.ConvertUtil;
 import com.freiheit.fuava.simplebatch.fetch.FetchedItem;
 import com.freiheit.fuava.simplebatch.processor.FileOutputStreamAdapter;
 import com.freiheit.fuava.simplebatch.result.Result;
+import com.freiheit.fuava.simplebatch.util.StringUtils;
 import com.freiheit.fuava.simplebatch.util.Sysprops;
 
 /**
@@ -51,7 +52,7 @@ public class SftpDownloadingFileWriterAdapter implements FileOutputStreamAdapter
     @Override
     public String getFileName( final Result<FetchedItem<SftpFilename>, SftpFilename> result ) {
         final String filename = result.getInput().getValue().getFilename();
-        final String count = com.google.common.base.Strings.padStart( Long.toString( counter.incrementAndGet() ), 3, '0' );
+        final String count = StringUtils.padStart( Long.toString( counter.incrementAndGet() ), 3, '0' );
         return prefix + "_" + count + "_" + filename;
     }
 
@@ -59,7 +60,6 @@ public class SftpDownloadingFileWriterAdapter implements FileOutputStreamAdapter
      * writes InputStream to OutputStream.
      *
      * @param outputStream data written from the sftp server
-     * @param inputStream data from the sftp server
      * @throws IOException when streaming fails.
      */
     @Override

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpFilename.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpFilename.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpOldFilesMovingLatestFileFetcher.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpOldFilesMovingLatestFileFetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,11 @@
  */
 package com.freiheit.fuava.sftp;
 
+import com.freiheit.fuava.sftp.util.FileType;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import com.freiheit.fuava.sftp.util.FileType;
-import com.google.common.collect.ImmutableMap;
 
 /**
  *
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableMap;
  * @author Thomas Ostendorf (thomas.ostendorf@freiheit.com)
  */
 public class SftpOldFilesMovingLatestFileFetcher extends SftpOldFilesMovingLatestMultiFileFetcher {
-
     private final FileType fileType;
     /**
      * ctor.
@@ -82,7 +81,6 @@ public class SftpOldFilesMovingLatestFileFetcher extends SftpOldFilesMovingLates
     @Override
     protected Map<FileType, List<String>> byType( final List<String> filenames ) {
         // TODO: filter for filetype matching names. Not really needed, because the timestamp extraction will filter again.
-        return ImmutableMap.of( this.fileType, filenames );
+        return Collections.singletonMap( this.fileType, filenames );
     }
-
 }

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpResultFileMover.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/SftpResultFileMover.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/util/ConvertUtil.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/util/ConvertUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/util/FileType.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/util/FileType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,15 +18,12 @@ package com.freiheit.fuava.sftp.util;
 
 import javax.annotation.Nonnull;
 
-import com.google.common.base.MoreObjects;
-
 /**
  * Describes the type of files to be processed.
  *
  * @author dmitrijs.barbarins@freiheit.com
  */
 public class FileType {
-
     public static final FileType ALL_FILES = new FileType( "all", "*" );
 
     private final String interfaceName;
@@ -101,12 +98,12 @@ public class FileType {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper( this )
-                .add( "interfaceName", interfaceName )
-                .add( "fileIdentifierPattern", fileIdentifierPattern )
-                .add( "fileExtention", fileExtention )
-                .add( "okFileExtention", okFileExtention )
-                .toString();
+        return "FileType{" +
+                "interfaceName='" + interfaceName + '\'' +
+                ", fileIdentifierPattern='" + fileIdentifierPattern + '\'' +
+                ", fileExtention='" + fileExtention + '\'' +
+                ", okFileExtention='" + okFileExtention + '\'' +
+                '}';
     }
 
     @Override

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/util/FilenameUtil.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/util/FilenameUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,22 +16,18 @@
  */
 package com.freiheit.fuava.sftp.util;
 
-import java.text.ParseException;
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import com.freiheit.fuava.sftp.RemoteFileStatus;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.LoggerFactory;
-
-import com.freiheit.fuava.sftp.RemoteFileStatus;
-import com.google.common.annotations.VisibleForTesting;
+import java.text.ParseException;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Util class for any operations on filenames.
@@ -41,8 +37,6 @@ import com.google.common.annotations.VisibleForTesting;
  */
 @ParametersAreNonnullByDefault
 public class FilenameUtil {
-
-    @VisibleForTesting
     public static final String DATE_TIME_PATTERN =
             "((19|20)\\d\\d)(0?[1-9]|1[012])(0?[1-9]|[12][0-9]|3[01])_((0[0-9]|1[0123456789]|2[0123])([0-5][0-9])([0-5][0-9]))";
 
@@ -241,7 +235,7 @@ public class FilenameUtil {
      * returned.
      */
     private static String getDateTimePattern( @Nullable final String lastDateTime ) {
-        return StringUtils.isEmpty( lastDateTime )
+        return lastDateTime == null || lastDateTime.isEmpty()
             ? DATE_TIME_PATTERN
             : lastDateTime;
     }

--- a/sftplib/src/main/java/com/freiheit/fuava/sftp/util/RemoteConfiguration.java
+++ b/sftplib/src/main/java/com/freiheit/fuava/sftp/util/RemoteConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sftplib/src/test/java/com/freiheit/fuava/sftp/FilenameUtilTest.java
+++ b/sftplib/src/test/java/com/freiheit/fuava/sftp/FilenameUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sftplib/src/test/java/com/freiheit/fuava/sftp/PseudoSFTPTest.java
+++ b/sftplib/src/test/java/com/freiheit/fuava/sftp/PseudoSFTPTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,7 +43,6 @@ import com.freiheit.fuava.simplebatch.processor.Processors;
 import com.freiheit.fuava.simplebatch.processor.TimeLoggingProcessor;
 import com.freiheit.fuava.simplebatch.result.ResultStatistics;
 import com.freiheit.fuava.simplebatch.util.FileUtils;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 
 @Test
@@ -67,17 +67,12 @@ public class PseudoSFTPTest {
 
         };
 
-        final HashMap<String, TestFolder<String>> initialState = new HashMap<String, TestFolder<String>>();
-        initialState.put(
-                "/incoming",
-                new TestFolder<String>(
-                        ImmutableMap.<String, String> builder()
-                                .put( downloadFileName, downloadFileContent )
-                                .put( "test_pseudo_152000_20101010_120000.ok", "" )
-                                .build()
+        final Map<String, String> folderContent = new LinkedHashMap<>();
+        folderContent.put( downloadFileName, downloadFileContent );
+        folderContent.put( "test_pseudo_152000_20101010_120000.ok", "" );
 
-                )
-                );
+        final HashMap<String, TestFolder<String>> initialState = new HashMap<String, TestFolder<String>>();
+        initialState.put( "/incoming", new TestFolder<>( folderContent ) );
 
         //prepare 'remote' state
 
@@ -164,17 +159,12 @@ public class PseudoSFTPTest {
 
         };
 
-        final HashMap<String, TestFolder<String>> initialState = new HashMap<String, TestFolder<String>>();
-        initialState.put(
-                "/incoming",
-                new TestFolder<String>(
-                        ImmutableMap.<String, String> builder()
-                                .put( downloadFileName, downloadFileContent )
-                                .put( "test_pseudo_152000_20101010_120000.ok", "" )
-                                .build()
+        final Map<String, String> folderContent = new LinkedHashMap<>();
+        folderContent.put( downloadFileName, downloadFileContent );
+        folderContent.put( "test_pseudo_152000_20101010_120000.ok", "" );
 
-                )
-                );
+        final HashMap<String, TestFolder<String>> initialState = new HashMap<String, TestFolder<String>>();
+        initialState.put( "/incoming", new TestFolder<>( folderContent ) );
 
         //prepare 'remote' state
 

--- a/sftplib/src/test/java/com/freiheit/fuava/sftp/SftpClientUnitTest.java
+++ b/sftplib/src/test/java/com/freiheit/fuava/sftp/SftpClientUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,6 @@
  */
 package com.freiheit.fuava.sftp;
 
-import com.google.common.collect.ImmutableList;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.SftpException;
 import org.apache.sshd.common.NamedFactory;
@@ -34,6 +33,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -122,10 +122,10 @@ public class SftpClientUnitTest {
         sshd.setPort( 0 );
         sshd.setKeyPairProvider( new SimpleGeneratorHostKeyProvider( Paths.get( "hostkey.set" ) ) );
 
-        final List<NamedFactory<UserAuth>> userAuthFactories = ImmutableList.of( UserAuthNoneFactory.INSTANCE );
+        final List<NamedFactory<UserAuth>> userAuthFactories = Collections.singletonList( UserAuthNoneFactory.INSTANCE );
         sshd.setUserAuthFactories(userAuthFactories);
 
-        final List<NamedFactory<Command>> namedFactoryList = ImmutableList.of( new SftpSubsystemFactory() );
+        final List<NamedFactory<Command>> namedFactoryList = Collections.singletonList( new SftpSubsystemFactory() );
         sshd.setSubsystemFactories(namedFactoryList);
 
         return sshd;

--- a/sftplib/src/test/java/com/freiheit/fuava/sftp/testclient/TestFolder.java
+++ b/sftplib/src/test/java/com/freiheit/fuava/sftp/testclient/TestFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 freiheit.com technologies gmbh
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ public final class TestFolder<T> {
     final ConcurrentMap<String, T> folderContent;
 
     public TestFolder( final Map<String, T> folderContent ) {
-        this.folderContent = new ConcurrentHashMap<String, T>( folderContent );
+        this.folderContent = new ConcurrentHashMap<>( folderContent );
     }
 
     public Set<String> getItemKeys() {


### PR DESCRIPTION
This commit removes all dependencies to Guava from Simplebatch.
It is a breaking change since SimpleBatch was relying heavily on
the functional interfaces provided by Guava. These have been replaced
by Java's default functional interfaces.